### PR TITLE
Add snap creation script and patch

### DIFF
--- a/makesnap
+++ b/makesnap
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+npm install
+patch -p1 < update-to-core22.patch
+npm run build
+npm run snap

--- a/update-to-core22.patch
+++ b/update-to-core22.patch
@@ -1,0 +1,36 @@
+From 03df44e17febc6bbcc21e2109afe0cc1f7ad9da0 Mon Sep 17 00:00:00 2001
+Message-Id: <03df44e17febc6bbcc21e2109afe0cc1f7ad9da0.1700180335.git.erich@ericheickmeyer.com>
+From: Erich Eickmeyer <erich@ericheickmeyer.com>
+Date: Thu, 16 Nov 2023 16:18:45 -0800
+Subject: [PATCH] Update to core22
+
+---
+ node_modules/app-builder-lib/templates/snap/snapcraft.yaml | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/node_modules/app-builder-lib/templates/snap/snapcraft.yaml b/node_modules/app-builder-lib/templates/snap/snapcraft.yaml
+index 08ed9604..803c644c 100644
+--- a/node_modules/app-builder-lib/templates/snap/snapcraft.yaml
++++ b/node_modules/app-builder-lib/templates/snap/snapcraft.yaml
+@@ -1,4 +1,4 @@
+-base: core18
++base: core22
+ grade: stable
+ confinement: strict
+ parts:
+@@ -130,10 +130,10 @@ parts:
+       - "-usr/lib/*/libXrandr*"
+       - "-usr/lib/*/libXrender*"
+ plugs:
+-  gnome-3-28-1804:
++  gnome-42-2204:
+     interface: content
+     target: $SNAP/gnome-platform
+-    default-provider: gnome-3-28-1804
++    default-provider: gnome-42-2204
+   gtk-3-themes:
+     interface: content
+     target: $SNAP/data-dir/themes
+-- 
+2.40.1
+


### PR DESCRIPTION
`electron-builder`, even in its latest iteration, still uses a template that has an out-of-date (End-Of-Life) snap core and gnome version (despite my urging the developers to update it). In order to keep the snap updated any further and keep it seeded in Ubuntu Studio, `electron-builder`'s `app-builder-lib` must be updated to a more current core and gnome version (`core22` and `gnome-42-2204`). Per my testing, Freeshow's snap still functions properly as snapped with this modification.

This PR simply adds a script to make my life easier when updating the snap by automatically patching the `app-builder-lib` component after `npm install` has been executed. Once the patch has been done from the included patch file, it then builds the application and snaps the build.

`electron-builder`'s documentation has a way to do this using the `package.json` file, but despite my many attempts, I was unable to do this, hence this is my solution.