### PR TITLE
Fix velocity override when only it is no index action, and check type match

### DIFF
--- a/src/frontend/utils/midi.ts
+++ b/src/frontend/utils/midi.ts
@@ -193,12 +193,16 @@ export function playMidiIn(msg) {
     let midi = get(midiIn)[msg.id]
     if (!midi) return
 
-    if (midi.values.velocity < 0) msg.values.velocity = midi.values.velocity
+    let is_index = midi.action?.includes("index_") ?? false
+    if (is_index) {
+        midi.values.velocity = msg.values.velocity
+    } else if (midi.values.velocity < 0) msg.values.velocity = midi.values.velocity
     if (JSON.stringify(midi.values) !== JSON.stringify(msg.values)) return
 
     if (midi.action) {
-        let index = midi.values.velocity
-        if (midi.action.includes("index_") && index < 0) {
+        if (midi.type !== msg.type) return
+        let index = msg.values.velocity
+        if (is_index && index < 0) {
             newToast("$toast.midi_no_velocity")
             index = 0
         }


### PR DESCRIPTION
midi value from the msg (midi in)'s velocity should not be overridden. UI is setting velocity to 0 when it is an index action.

To get midi value-match check working, writing it the other way, from msg (actual midi in) to the midi requirement.

Type wasn't checked too, and should too be checked.