### PR TITLE
Fix ProPresenter file import issue with negative unicode characters

### DIFF
--- a/src/frontend/converters/propresenter.ts
+++ b/src/frontend/converters/propresenter.ts
@@ -331,8 +331,8 @@ function decodeBase64(text: string) {
     while (decCode > -1) {
         let endOfCode = r.indexOf(" ?", decCode) + 2
 
-        if (endOfCode > 1 && endOfCode - decCode < 10) {
-            let decodedLetter = String.fromCharCode(Number(r.slice(decCode, endOfCode).replace(/\D/g, "")))
+        if (endOfCode > 1 && endOfCode - decCode <= 10) {
+            let decodedLetter = String.fromCharCode(Number(r.slice(decCode, endOfCode).replace(/[^\d-]/g, "")))
             if (!decodedLetter.includes("\\x")) r = r.slice(0, decCode) + decodedLetter + r.slice(endOfCode)
         }
 


### PR DESCRIPTION
**I've made a fix to address the ProPresenter file import problem. This change fix the decoding function to properly handle negative unicode characters.**

Here's an example with some Chinese characters encoded in negative unicode.

_Before the fix:_
![image](https://github.com/ChurchApps/FreeShow/assets/150692919/6122e499-5631-4108-9f56-c8dd1f1207b9)

_After the fix:_
![image](https://github.com/ChurchApps/FreeShow/assets/150692919/980ab169-d035-4240-8d2b-16691beb4aea)

