### PR TITLE
Update makesnap and update-to-core22.patch (fixes #424)

### DIFF
--- a/makesnap
+++ b/makesnap
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 npm install
 patch -p1 < update-to-core22.patch

--- a/update-to-core22.patch
+++ b/update-to-core22.patch
@@ -13,7 +13,7 @@ index 08ed9604..803c644c 100644
 --- a/node_modules/app-builder-lib/templates/snap/snapcraft.yaml
 +++ b/node_modules/app-builder-lib/templates/snap/snapcraft.yaml
 @@ -1,4 +1,4 @@
--base: core18
+-base: core20
 +base: core22
  grade: stable
  confinement: strict


### PR DESCRIPTION
Unbeknownst to me, `electron-builder` updated their snap template to `core20`, which only kicks the can down the road by an additional year for them. This keeps freeshow more future-proof by keeping it up-to-date with the latest core and gnome dependencies (`core22` and `gnome-42-2204`).

This also ensures I catch the problem earlier by making the `makesnap` script fail upon error, keying me in that something went terribly wrong and getting my attention sooner.

FYI, the Freeshow snap has already been updated with these changes.