### PR TITLE
Improvements to open song converter

### DIFF
--- a/src/frontend/converters/opensong.ts
+++ b/src/frontend/converters/opensong.ts
@@ -70,8 +70,8 @@ function createSlides({ lyrics }: Song) {
     lyrics.forEach((slide) => {
         let lines = slide.split("\n")
         let group = lines.splice(0, 1)[0]
-        let chords = lines.filter((_v: string, i: number) => !(i % 2))
-        let text = lines.filter((_v: string, i: number) => i % 2)
+        let chords = lines.filter((_v: string) => _v.startsWith("."))
+        let text = lines.filter((_v: string) => !_v.startsWith("."))
         if (text) {
             let id: string = uid()
             layout.push({ id })

--- a/src/frontend/converters/opensong.ts
+++ b/src/frontend/converters/opensong.ts
@@ -67,6 +67,7 @@ const OSgroups: any = { V: "verse", C: "chorus", B: "bridge", T: "tag", O: "outr
 function createSlides({ lyrics }: Song) {
     let slides: any = {}
     let layout: any[] = []
+    if (!lyrics) return {slides, layout};
     lyrics.forEach((slide) => {
         let lines = slide.split("\n")
         let group = lines.splice(0, 1)[0]


### PR DESCRIPTION
Hi guys, I was importing my songs from OpenSong to FreeShow when I noticed that only the even lines of each verse block was beeing added.

Example of lyrics tag that we currently use:

~~~
<lyrics>[V1]
 Noche de paz, noche de amor
 Todo duerme en derredor.
 Entre los astros que esparcen su luz,

[V2]
 Bella anunciando al niñito Jesús,
 Brilla la estrella de paz, brilla la estrella de paz.

[V3]
 Noche de paz, noche de amor
 Oye humilde el fiel pastor.
 Coros celestes que anuncian salud,

[V4]
 Gracias y glorias en gran plenitud,
 //Por nuestro buen Redentor //.

[V5]
 ¡Noche de paz, 
 noche de amor!
 Ved qué bello 
 resplandor.

[V6]
 Luce en el rostro del niño Jesús,
 En el pesebre, del mundo la luz,
 // Astro de eterno fulgor //.
</lyrics>
~~~

I saw that you had an split on lyrics for chords, I changed it to get the cords by all the lines that starts with a dot (I'm not sure if all the chords have to start with a dot, we have never used chords but all the example songs that open song have the chords starts with a dot).

I also noticed that I was importing a file with only a title:

~~~
<?xml version="1.0" encoding="UTF-8"?>
<song>
  <title>digno </title></song>
~~~

 It was throwing an null pointer exception so I decided to add a check to files with empty lyrics that returns empty slides.

Hope it helps 🙏🏽