### PR TITLE
Fix-Show-Groups-Sort

### DIFF
--- a/src/frontend/components/show/tools/SlideGroups.svelte
+++ b/src/frontend/components/show/tools/SlideGroups.svelte
@@ -10,7 +10,7 @@
     import Icon from "../../helpers/Icon.svelte"
     import { _show } from "../../helpers/shows"
 
-    $: showGroups = $cachedShowsData[$activeShow!.id]?.groups || []
+    $: showGroups = $cachedShowsData[$activeShow!.id]?.groups.sort(orderGroups) || []
 
     $: layoutSlides = $showsCache[$activeShow!.id]?.layouts?.[_show().get("settings.activeLayout")]?.slides || []
     $: console.log(layoutSlides)
@@ -19,6 +19,19 @@
         return count
     }
 
+    function orderGroups(a: any, b: any) {
+        const aGroupType = a.group.split(' ')[0];
+        const bGroupType = b.group.split(' ')[0];
+
+        if (aGroupType !== bGroupType) {
+            return aGroupType.localeCompare(bGroupType);
+        }
+
+        const groupA = parseInt(a.group.split(' ')[1]) || 0;
+        const groupB = parseInt(b.group.split(' ')[1]) || 0;
+        return groupA - groupB;
+    }
+    
     $: globalGroups = Object.entries($groups).map(([id, group]: any) => {
         let name = group.name
         if (group.default) name = $dictionary.groups?.[group.name]


### PR DESCRIPTION
Hi again!

I saw that the show groups where not sorted correctly, because they were sorted by strings and not by the number of the group name so I fixed it

This is the before and after of the change:

Before:
![image](https://github.com/ChurchApps/FreeShow/assets/61138950/8d8e593e-8a3c-4d63-b8d4-53d922cc398e)

After:
![image](https://github.com/ChurchApps/FreeShow/assets/61138950/073a7bc9-2095-4689-8285-ff6a7e9cb1e1)
