### PR TITLE
Create text boxes for every text box on powerpoint

### DIFF
--- a/src/frontend/converters/powerpoint.ts
+++ b/src/frontend/converters/powerpoint.ts
@@ -1,6 +1,6 @@
 import { get } from "svelte/store"
 import { uid } from "uid"
-import type { Show, Slide } from "../../types/Show"
+import type { Item, Show, Slide } from "../../types/Show"
 import { ShowObj } from "../classes/Show"
 import { checkName } from "../components/helpers/show"
 import { activePopup, alertMessage, dictionary } from "../stores"
@@ -77,8 +77,11 @@ function createSlides(slides: string[][]) {
         let id: string = uid()
         layouts.push({ id })
 
-        let items = [{ style: "left:50px;top:120px;width:1820px;height:840px;", lines: slide.map((a: any) => ({ align: "text-align: left;", text: [{ style: "", value: a }] })) }]
-
+        let items : Item[] = []
+        slide.forEach(line => {
+            items.push({style: "left:50px;top:120px;width:1820px;height:840px;", lines: [{align: "text-align: left;", text: [{ style: "", value: line }]}]})
+        });
+        
         slidesObj[id] = {
             group: (i + 1).toString(),
             color: null,


### PR DESCRIPTION
Hi guys!

On our church we have a template for power point slides likes this:

![image](https://github.com/ChurchApps/FreeShow/assets/61138950/08d0e27e-6b23-4d9c-a007-61e2271d7c58)

To replicate it on FreeShow using the PowerPoint utility we need to have as much text boxes as power point have. For example "Esto es un titulo" is a text box and "I. Amor" Is another text box, with this we can create a template on free show to move every text to the correct position as it is on PowerPoint

![image](https://github.com/ChurchApps/FreeShow/assets/61138950/b5c860ef-7e7a-4e90-9812-3c9b5400d5c1)

Sorry If i didn`t explain it well.

Hope there is no issue on adding this. Thanks! 😄