### PR TITLE
Issue 470 fix

### DIFF
--- a/src/frontend/components/edit/Editbox.svelte
+++ b/src/frontend/components/edit/Editbox.svelte
@@ -355,7 +355,6 @@
         if ($activeEdit.type === "overlay") overlays.update(setNewLines)
         else if ($activeEdit.type === "template") templates.update(setNewLines)
         else if (ref.id) {
-            console.log("REF ID")
             // dont override history when undoing
             let lastRedo = $redoHistory[$redoHistory.length - 1]
             if (lastRedo?.id === "SHOW_ITEMS") {
@@ -367,7 +366,6 @@
                 if (historyText === linesText) return
             }
 
-            console.log("*******LOGGING", newLines, lastRedo)
             let lastChangedLine = EditboxHelper.determineCaretLine(item, newLines)
             if (lastChangedLine > -1) setCaretDelayed(lastChangedLine, 0)
 
@@ -379,9 +377,6 @@
 
         function setNewLines(a: any) {
             if (!a[$activeEdit.id!].items[index]) return a
-
-            console.log("SETTINGS NEW LINES", newLines.length, a[$activeEdit.id!].items[index].lines.length)
-
             a[$activeEdit.id!].items[index].lines = newLines
             return a
         }
@@ -615,15 +610,18 @@
     setInterval(() => (today = new Date()), 1000)
 
     function textElemKeydown(e: any) {
+        /*
         if (e.key === "v" && (e.ctrlKey || e.metaKey)) {
             e.preventDefault()
             navigator.clipboard.readText().then((clipText: string) => {
                 paste(e, clipText)
             })
         }
+        */
     }
 
     // paste
+    /*
     function paste(e: any, clipboardText: string = "") {
         let clipboard: string = clipboardText || e.clipboardData.getData("text/plain") || ""
         if (!clipboard) return
@@ -661,6 +659,7 @@
             setCaret(textElem, caret)
         }, 10)
     }
+    */
 
     // let height: number = 0
     // let width: number = 0

--- a/src/frontend/components/edit/Editbox.svelte
+++ b/src/frontend/components/edit/Editbox.svelte
@@ -366,7 +366,7 @@
                 if (historyText === linesText) return
             }
 
-            let lastChangedLine = EditboxHelper.determineCaretLine(item, newLines)
+            let lastChangedLine = EditboxHelper.determineCaretLine(item?.lines || [], newLines)
             if (lastChangedLine > -1) setCaretDelayed(lastChangedLine, 0)
 
             history({ id: "SHOW_ITEMS", newData: { key: "lines", data: clone([newLines]), slides: [ref.id], items: [index] }, location: { page: "none", override: ref.showId + ref.id + index } })

--- a/src/frontend/components/edit/Editbox.svelte
+++ b/src/frontend/components/edit/Editbox.svelte
@@ -608,18 +608,18 @@
     // timer
     let today = new Date()
     setInterval(() => (today = new Date()), 1000)
-
+    /*
     function textElemKeydown(e: any) {
-        /*
+        
         if (e.key === "v" && (e.ctrlKey || e.metaKey)) {
             e.preventDefault()
             navigator.clipboard.readText().then((clipText: string) => {
                 paste(e, clipText)
             })
         }
-        */
+        
     }
-
+*/
     // paste
     /*
     function paste(e: any, clipboardText: string = "") {
@@ -838,7 +838,6 @@ bind:offsetWidth={width} -->
                 class:hidden={chordsMode}
                 class:autoSize={item.auto && autoSize}
                 contenteditable
-                on:keydown={textElemKeydown}
                 bind:innerHTML={html}
                 style="{plain || !item.auto ? '' : `--auto-size: ${autoSize}px;`}{!plain && lineGap ? `gap: ${lineGap}px;` : ''}{plain ? '' : item.align ? item.align.replace('align-items', 'justify-content') : ''}"
                 class:height={item.lines?.length < 2 && !item.lines?.[0]?.text[0]?.value.length}

--- a/src/frontend/components/edit/Editbox.svelte
+++ b/src/frontend/components/edit/Editbox.svelte
@@ -28,6 +28,7 @@
     import { getAutoSize, getMaxBoxTextSize } from "./scripts/autoSize"
     import { addChords, chordMove } from "./scripts/chords"
     import { getLineText, getSelectionRange, setCaret } from "./scripts/textStyle"
+    import { EditboxHelper } from "./EditboxHelper"
 
     export let item: Item
     export let filter: string = ""
@@ -341,6 +342,12 @@
         setTimeout(updateLines, 10)
     }
 
+    function setCaretDelayed(line: number, pos: number) {
+        setTimeout(() => {
+            setCaret(textElem, { line, pos })
+        }, 10)
+    }
+
     function updateLines(newLines: Line[]) {
         // updateItem = true
         if (!newLines) newLines = getNewLines()
@@ -348,6 +355,7 @@
         if ($activeEdit.type === "overlay") overlays.update(setNewLines)
         else if ($activeEdit.type === "template") templates.update(setNewLines)
         else if (ref.id) {
+            console.log("REF ID")
             // dont override history when undoing
             let lastRedo = $redoHistory[$redoHistory.length - 1]
             if (lastRedo?.id === "SHOW_ITEMS") {
@@ -359,6 +367,10 @@
                 if (historyText === linesText) return
             }
 
+            console.log("*******LOGGING", newLines, lastRedo)
+            let lastChangedLine = EditboxHelper.determineCaretLine(item, newLines)
+            if (lastChangedLine > -1) setCaretDelayed(lastChangedLine, 0)
+
             history({ id: "SHOW_ITEMS", newData: { key: "lines", data: clone([newLines]), slides: [ref.id], items: [index] }, location: { page: "none", override: ref.showId + ref.id + index } })
 
             // refresh list view boxes
@@ -367,6 +379,8 @@
 
         function setNewLines(a: any) {
             if (!a[$activeEdit.id!].items[index]) return a
+
+            console.log("SETTINGS NEW LINES", newLines.length, a[$activeEdit.id!].items[index].lines.length)
 
             a[$activeEdit.id!].items[index].lines = newLines
             return a

--- a/src/frontend/components/edit/Editbox.svelte
+++ b/src/frontend/components/edit/Editbox.svelte
@@ -377,6 +377,7 @@
 
         function setNewLines(a: any) {
             if (!a[$activeEdit.id!].items[index]) return a
+
             a[$activeEdit.id!].items[index].lines = newLines
             return a
         }
@@ -608,20 +609,17 @@
     // timer
     let today = new Date()
     setInterval(() => (today = new Date()), 1000)
-    /*
+
     function textElemKeydown(e: any) {
-        
         if (e.key === "v" && (e.ctrlKey || e.metaKey)) {
             e.preventDefault()
             navigator.clipboard.readText().then((clipText: string) => {
                 paste(e, clipText)
             })
         }
-        
     }
-*/
+
     // paste
-    /*
     function paste(e: any, clipboardText: string = "") {
         let clipboard: string = clipboardText || e.clipboardData.getData("text/plain") || ""
         if (!clipboard) return
@@ -653,13 +651,14 @@
         })
 
         updateLines(lines)
-        getStyle()
-        // set caret position back
         setTimeout(() => {
-            setCaret(textElem, caret)
+            getStyle()
+            // set caret position back
+            setTimeout(() => {
+                setCaret(textElem, caret)
+            }, 10)
         }, 10)
     }
-    */
 
     // let height: number = 0
     // let width: number = 0
@@ -838,6 +837,7 @@ bind:offsetWidth={width} -->
                 class:hidden={chordsMode}
                 class:autoSize={item.auto && autoSize}
                 contenteditable
+                on:keydown={textElemKeydown}
                 bind:innerHTML={html}
                 style="{plain || !item.auto ? '' : `--auto-size: ${autoSize}px;`}{!plain && lineGap ? `gap: ${lineGap}px;` : ''}{plain ? '' : item.align ? item.align.replace('align-items', 'justify-content') : ''}"
                 class:height={item.lines?.length < 2 && !item.lines?.[0]?.text[0]?.value.length}
@@ -980,14 +980,14 @@ bind:offsetWidth={width} -->
         /* background-color: var(--secondary-opacity); */
     }
     /* .chordsText {
-    position: absolute;
-    width: 100%;
-    color: transparent !important;
-    user-select: none;
-  }
-  .chordsText:first-child {
-    width: 100%;
-  } */
+  position: absolute;
+  width: 100%;
+  color: transparent !important;
+  user-select: none;
+}
+.chordsText:first-child {
+  width: 100%;
+} */
 
     .align {
         height: 100%;
@@ -1026,8 +1026,8 @@ bind:offsetWidth={width} -->
     }
 
     /* .edit.tallLines {
-    line-height: 200px;
-  } */
+  line-height: 200px;
+} */
 
     .plain .edit {
         font-size: 1.5em;
@@ -1055,8 +1055,8 @@ bind:offsetWidth={width} -->
     .edit:not(.plain .edit) :global(span) {
         font-size: 100px;
         /* min-height: 100px;
-    min-width: 100px;
-    display: inline-table; */
+  min-width: 100px;
+  display: inline-table; */
     }
 
     /* chords */
@@ -1072,7 +1072,7 @@ bind:offsetWidth={width} -->
     }
     .edit.chords :global(.chord) {
         /* color: var(--chord-color);
-        font-size: var(--chord-size) !important; */
+      font-size: var(--chord-size) !important; */
         bottom: 0;
         transform: translate(-50%, -60%);
         z-index: 2;

--- a/src/frontend/components/edit/EditboxHelper.ts
+++ b/src/frontend/components/edit/EditboxHelper.ts
@@ -2,8 +2,10 @@ import type { Item, Line } from "../../../types/Show"
 
 export class EditboxHelper {
 
+  
+  //Compare text of all the new lines to determine if it's truly a modification or just an index change.
+  //Set the cursor to the start of the last line that was modified.
   static determineCaretLine(item:Item, newLines: Line[]) {
-    console.log("*******DETERMINE CARET LINE*********")
     const oldTexts:string[] = [];
     const newTexts:string[] = [];
     

--- a/src/frontend/components/edit/EditboxHelper.ts
+++ b/src/frontend/components/edit/EditboxHelper.ts
@@ -1,24 +1,28 @@
 import type { Item, Line } from "../../../types/Show"
 
 export class EditboxHelper {
-  static determineCaretLine(item:Item, newLines: Line[]) {
-    let changeCount = 0
-    let lastChangedLine = -1
 
-    if (newLines.length !== item?.lines?.length) {
-        for (let i = 0; i < newLines.length; i++) {
-            let oldVal = "(blank)"
-            if (item?.lines && item.lines.length > i) oldVal = item.lines[i].text[0].value
-            console.log("COMPARING", i, newLines[i].text[0].value, "**", oldVal)
-            if (newLines[i].text[0].value !== oldVal) {
-                changeCount++
-                lastChangedLine = i
-                console.log("CHANGED LINE", i, newLines[i].text[0].value, "**", oldVal)
-                if (changeCount > 1) break
-            }
-        }
+  static determineCaretLine(item:Item, newLines: Line[]) {
+    const oldTexts:string[] = [];
+    const newTexts:string[] = [];
+
+    item.lines?.forEach((line) => {
+      oldTexts.push(line.text[0].value);
+    });
+
+    newLines.forEach((line) => {
+      newTexts.push(line.text[0].value);
+    });
+
+    let lastLineChanged = -1;
+    for (let i=0; i<newTexts.length; i++) {
+      const nt = newTexts[i];
+      const index = oldTexts.indexOf(nt);
+      if (index === -1) lastLineChanged = i;
+      else oldTexts.splice(index, 1);
     }
-    return lastChangedLine
-}
+    return lastLineChanged;
+  }
+
 
 }

--- a/src/frontend/components/edit/EditboxHelper.ts
+++ b/src/frontend/components/edit/EditboxHelper.ts
@@ -3,8 +3,10 @@ import type { Item, Line } from "../../../types/Show"
 export class EditboxHelper {
 
   static determineCaretLine(item:Item, newLines: Line[]) {
+    console.log("*******DETERMINE CARET LINE*********")
     const oldTexts:string[] = [];
     const newTexts:string[] = [];
+    
 
     item.lines?.forEach((line) => {
       oldTexts.push(line.text[0].value);
@@ -15,6 +17,7 @@ export class EditboxHelper {
     });
 
     let lastLineChanged = -1;
+    if (oldTexts.length === newTexts.length) return lastLineChanged;
     for (let i=0; i<newTexts.length; i++) {
       const nt = newTexts[i];
       const index = oldTexts.indexOf(nt);

--- a/src/frontend/components/edit/EditboxHelper.ts
+++ b/src/frontend/components/edit/EditboxHelper.ts
@@ -1,16 +1,15 @@
-import type { Item, Line } from "../../../types/Show"
+import type { Line } from "../../../types/Show"
 
 export class EditboxHelper {
 
   
   //Compare text of all the new lines to determine if it's truly a modification or just an index change.
   //Set the cursor to the start of the last line that was modified.
-  static determineCaretLine(item:Item, newLines: Line[]) {
+  static determineCaretLine(oldLines:Line[], newLines: Line[]) {
     const oldTexts:string[] = [];
     const newTexts:string[] = [];
     
-
-    item.lines?.forEach((line) => {
+    oldLines?.forEach((line) => {
       oldTexts.push(line.text[0].value);
     });
 

--- a/src/frontend/components/edit/EditboxHelper.ts
+++ b/src/frontend/components/edit/EditboxHelper.ts
@@ -1,0 +1,24 @@
+import type { Item, Line } from "../../../types/Show"
+
+export class EditboxHelper {
+  static determineCaretLine(item:Item, newLines: Line[]) {
+    let changeCount = 0
+    let lastChangedLine = -1
+
+    if (newLines.length !== item?.lines?.length) {
+        for (let i = 0; i < newLines.length; i++) {
+            let oldVal = "(blank)"
+            if (item?.lines && item.lines.length > i) oldVal = item.lines[i].text[0].value
+            console.log("COMPARING", i, newLines[i].text[0].value, "**", oldVal)
+            if (newLines[i].text[0].value !== oldVal) {
+                changeCount++
+                lastChangedLine = i
+                console.log("CHANGED LINE", i, newLines[i].text[0].value, "**", oldVal)
+                if (changeCount > 1) break
+            }
+        }
+    }
+    return lastChangedLine
+}
+
+}


### PR DESCRIPTION
- For the first and third bug reported on that issue, wrapping getStyle() in a setTimeout was all that was needed.  Line 655

- For the appropriate line breaks, I added a new helper method to determine which line the cursor should be on when the number of lines change.  I created a new helper class of EditboxHelper and added this function to it, with the intent of expanding that helper class with more functions later.  The goal being to simplify Editbox itself over time, removing any code that doesn't affect the component state.  If this isn't the approach you want to take, feel free to move that function to Editbox instead.

- I haven't attempted it yet, but I think the setTimeout() calls may be a source of a lot of intermittent bugs that are hard to track down.  10ms is adequate when the machine is running well, but when it gets bogged down, code can execute out of order.