### PR TITLE
Add more checks on whether the note is correct

### DIFF
--- a/src/frontend/components/actions/midi.ts
+++ b/src/frontend/components/actions/midi.ts
@@ -97,7 +97,10 @@ export function receivedMidi(msg) {
 
     // the select slide index from velocity can't select slide 0 as a NoteOn with velocity 0 is detected as NoteOff
     // velocity of 0 currently bypasses the note on/off
-    if (action.midi?.type !== msg.type && index !== 0) return
+    const diff_type = action.midi?.type !== msg.type
+    const diff_note = msg.values.note !== action.midi?.values.note
+    const diff_channel = msg.values.channel !== action.midi?.values.channel
+    if ((diff_type || diff_note || diff_channel) && index !== 0) return
 
     let hasindex = action.triggers?.[0]?.includes("index_") ?? false
     if (hasindex && index < 0) {


### PR DESCRIPTION
Not sure why on MacOS, it seems to repeat the same note for all the Midi id, and if we are not checking the channel/note, it will go crazy and execute basically available action.

This add the checks for channel and note, so that it will only fire if the channel and note are matching the action. Not sure if this is the right fix, or if something can be fix on the midi initial dispatching.