### PR TITLE
Add playwright config and github worklow to run e2e test

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,34 @@
+name: Playwright Tests
+on:
+    push:
+        branches: [main, dev]
+    pull_request:
+        branches: [main, dev]
+    workflow_dispatch:
+
+jobs:
+    test:
+        timeout-minutes: 60
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@master
+              with:
+                  node-version: 18
+            - name: Install dependencies
+              run: npm install
+            - name: Install Playwright Browsers
+              run: npx playwright install --with-deps
+            - name: Build
+              run: npm run build
+            - name: Run Playwright tests
+              run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- npm run test:playwright
+            #   if: matrix.os == 'ubuntu-latest'
+            # - run: npm run test
+            #   if: matrix.os != 'ubuntu-latest'
+            - uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: test-output
+                  path: test-output/
+                  retention-days: 30

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Downloads](https://img.shields.io/github/downloads/ChurchApps/freeshow/total)](https://github.com/ChurchApps/freeshow/releases)
 [![Licence](https://img.shields.io/badge/licence-GPL-blue.svg)](https://github.com/ChurchApps/freeshow/blob/main/LICENSE)
+![dev - E2E Test](https://github.com/ChurchApps/FreeShow/actions/workflows/playwright.yml/badge.svg?branch=dev)
 
 # FreeShow
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Downloads](https://img.shields.io/github/downloads/ChurchApps/freeshow/total)](https://github.com/ChurchApps/freeshow/releases)
 [![Licence](https://img.shields.io/badge/licence-GPL-blue.svg)](https://github.com/ChurchApps/freeshow/blob/main/LICENSE)
-![dev - E2E Test](https://github.com/ChurchApps/FreeShow/actions/workflows/playwright.yml/badge.svg?branch=dev)
+[![Playwright Tests](https://github.com/ChurchApps/FreeShow/actions/workflows/playwright.yml/badge.svg?branch=dev)](https://github.com/ChurchApps/FreeShow/actions/workflows/playwright.yml)
 
 # FreeShow
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+    // 'github' for GitHub Actions CI to generate annotations, plus a concise 'dot'
+    // default 'line' when running locally
+    reporter: [[process.env.CI ? "html" : "line", { outputFolder: "test-output/playwright-report" }]],
+})


### PR DESCRIPTION
After landing the machine independent e2e test, it enables us to start doing CI on github, as it won't matter with previous setup.

Having the ability to mock out the settings and show data storage, also allows us to test with different preset settings and show data, this allows us to test a few things
- Old settings/show data won't be broken with newer code/testing if migration works.
- Making sure no unexpected UI is showing up with specific settings, i.e. start up screen should show up with old settings.

This allows us to test many more things and will ensure the quality of releases.