### PR TITLE
Made preview video time syncing less aggressive

### DIFF
--- a/src/frontend/components/output/layers/BackgroundMedia.svelte
+++ b/src/frontend/components/output/layers/BackgroundMedia.svelte
@@ -59,7 +59,13 @@
     $: if (mirror && $videosData[outputId]?.paused) videoData.paused = true
     $: if (mirror && $videosData[outputId]?.paused === false) videoData.paused = false
 
-    $: if (mirror && $videosTime[outputId]) videoTime = $videosTime[outputId]
+    $: if (mirror && $videosTime[outputId]) {
+        const diff = Math.abs($videosTime[outputId] - videoTime)
+        if (diff > 0.5) {
+            videoTime = $videosTime[outputId]
+            videoData.paused = $videosData[outputId]?.paused
+        }
+    }
 
     $: if (!mirror && !fadingOut) send(OUTPUT, ["MAIN_DATA"], { [outputId]: videoData })
     $: if (!mirror && !fadingOut) sendVideoTime(videoTime)


### PR DESCRIPTION
The preview video time stamp is pretty much always a few milliseconds off from the main output.  By trying to bring it back in perfect sync we're making the problem worse because it stalls for a moment when skipping ahead or back, putting it further out of sync.  Doing this dozens of times per second causes the video to stutter.  I updated it to only do this if we're at least 500ms out of sync.