### PR TITLE
Added python installation instructions to building instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ You are welcome to contribute to the code!
 
 1. Clone the code in this repo
 2. Install [Node.js](https://nodejs.org/en/download/)
-3. In the terminal, run: `npm install`
-4. To start the app, run: `npm start`
+3. Install Python 3.11 or install Python 3.12 with the `setuptools` package
+4. In the terminal, run: `npm install`
+5. To start the app, run: `npm start`
 
 ## Join us on Slack
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ You are welcome to contribute to the code!
 
 1. Clone the code in this repo
 2. Install [Node.js](https://nodejs.org/en/download/)
-3. Install Python 3.11 or install Python 3.12 with the `setuptools` package
+3. Install [Python 3.11](https://www.python.org/downloads/release/python-3119/) or install [Python 3.12](https://www.python.org/downloads/) with the `setuptools` package
 4. In the terminal, run: `npm install`
 5. To start the app, run: `npm start`
 


### PR DESCRIPTION
Quick pull request to add python installation instructions. I found that when I had python3.12 installed, I couldn't build FreeShow until I had the `setuputils` python package. Hopefully it helps someone later on :).