### PR TITLE
Fix snap to bind entire /usr/share/alsa directory (fixes #994)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,8 +32,8 @@ plugs:
     target: $SNAP/data-dir/sounds
     default-provider: gtk-common-themes
 layout:
-  /usr/share/alsa/alsa.conf:
-    bind-file: $SNAP_DATA/usr/share/alsa/alsa.conf
+  /usr/share/alsa:
+    bind: $SNAP/usr/share/alsa
 parts:
   freeshow:
     source: ./dist/linux-unpacked/


### PR DESCRIPTION
This commit binds the entire /usr/share/alsa directory so that freeshow can use it within the snap, making it so that MIDI functions don't crash. Fixes #994 