### PR TITLE
Snap app packaging tweak: Add removable-media to snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -54,6 +54,7 @@ apps:
       - audio-playback
       - pulseaudio
       - opengl
+      - removable-media
     environment:
       PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$PATH
       SNAP_DESKTOP_RUNTIME: $SNAP/gnome-platform


### PR DESCRIPTION
Users who install FreeShow via Snap package (i.e. Ubuntu Store) cannot import/export files to removable media due to the sandboxing.

Fix:
This PR adds "removable-media" to `snapcraft.yaml` so that we (as the publisher of the FreeShow package) indicate that the application _can_ use removable media.

Note:
The user may still need to manually enable the permission, but at least they will now have "removable media" as a permission they can enable. See https://askubuntu.com/a/1267296 and https://snapcraft.io/docs/interface-management#heading--auto-connections