### PR TITLE
Automate version in snapcraft.yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "express": "^4.17.2",
                 "follow-redirects": "^1.15.2",
                 "genius-lyrics": "^4.4.7",
-                "grandiose": "github:vassbo/grandiose#c5536df",
+                "grandiose": "github:vassbo/grandiose#5b1fc57",
                 "jzz": "^1.8.7",
                 "mp4box": "^0.5.2",
                 "node-machine-id": "^1.1.12",
@@ -4233,7 +4233,7 @@
         },
         "node_modules/grandiose": {
             "version": "6.11.0",
-            "resolved": "git+ssh://git@github.com/vassbo/grandiose.git#c5536df27725951b33ce43de3db2f2c9777ce48d",
+            "resolved": "git+ssh://git@github.com/vassbo/grandiose.git#5b1fc57e22407af5ff4a8bb9aff849145dce0cef",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {


### PR DESCRIPTION
This is mostly to make my life easier every time I build the snap. Merely changes the `version` line to match the one in `project.json` when `makesnap` is run.