### PR TITLE
fix: create a new dir for each project import

### DIFF
--- a/src/electron/data/import.ts
+++ b/src/electron/data/import.ts
@@ -1,14 +1,14 @@
-import path, { join } from "path";
-import PPTX2Json from "pptx2json";
-import protobufjs from "protobufjs";
-import SqliteToJson from "sqlite-to-json";
-import sqlite3 from "sqlite3";
-import WordExtractor from "word-extractor";
-import { toApp } from "..";
-import { IMPORT, MAIN } from "../../types/Channels";
-import { dataFolderNames, doesPathExist, getDataFolder, getExtension, makeDir, readFileAsync, readFileBufferAsync, writeFile } from "../utils/files";
-import { detectFileType } from "./bibleDetecter";
-import { decompress, isZip } from "./zip";
+import path, { join } from "path"
+import PPTX2Json from "pptx2json"
+import protobufjs from "protobufjs"
+import SqliteToJson from "sqlite-to-json"
+import sqlite3 from "sqlite3"
+import WordExtractor from "word-extractor"
+import { toApp } from ".."
+import { IMPORT, MAIN } from "../../types/Channels"
+import { dataFolderNames, doesPathExist, getDataFolder, getExtension, makeDir, readFileAsync, readFileBufferAsync, writeFile } from "../utils/files"
+import { decompress, isZip } from "./zip"
+import { detectFileType } from "./bibleDetecter"
 
 const specialImports: any = {
     powerpoint: async (files: string[]) => {


### PR DESCRIPTION
This PR changes the `importProject` function to create a new folder named after the current datetime for each project import to avoid name collisions.

Fixes #1227