### PR TITLE
retry-after should be lowercase

### DIFF
--- a/src/electron/planningcenter/request.ts
+++ b/src/electron/planningcenter/request.ts
@@ -39,7 +39,7 @@ export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any
                 // handle rate limit
                 // https://developer.planning.center/docs/#/overview/rate-limiting
                 if (err.statusCode === 429) {
-                    const retryAfter = parseInt(err?.headers?.["Retry-After"]) || 2
+                    const retryAfter = parseInt(err?.headers?.["retry-after"]) || 2
                     rateLimit(retryAfter)
                     return
                 }


### PR DESCRIPTION
I tested the dev branch for the rate-limit issue of planning center, it does not use the retry-after from the header. Apparently the header is lower-case.

<img width="440" alt="image" src="https://github.com/user-attachments/assets/9850c916-7003-45ce-91df-50754655ccbf" />
