### PR TITLE
Fix makesnap for commit that organized the scripts

### DIFF
--- a/makesnap
+++ b/makesnap
@@ -5,6 +5,11 @@ version=$(grep "\"version\"" package.json | cut -d ":" -f 2 | cut -d "\"" -f 2)
 sed -i "s/version:.*/version: ${version}/" config/building/snapcraft.yaml
 npm install
 npm run build
-npm run pack
+npm run release
+chmod +x scripts/snap/*.sh
+mkdir snap
+mv scripts/snap/gui snap
+mv config/building/snapcraft.yaml snap
 cp scripts/snap/*.sh dist/linux-unpacked
-snapcraft
+snapcraft --verbose
+


### PR DESCRIPTION
The initiative to organize the scripts broke the snap building process. Snaps require a very specific structure and the `snap` directory _must_ be in the root of the repository. WIthout this, it fundamentally breaks.

Additionally, the removal of the executable bit from the scripts caused the entire build to fail as the scripts _must_ be executable in order for the build to succeed and the installed snap to function at all.

I have revised the `makesnap` script to accommodate the changes and move the required files to a `snap` directory during build so it may build properly.