### PR TITLE
Adding transpose functionality to text edit (not working fully)

### DIFF
--- a/makesnap
+++ b/makesnap
@@ -5,6 +5,11 @@ version=$(grep "\"version\"" package.json | cut -d ":" -f 2 | cut -d "\"" -f 2)
 sed -i "s/version:.*/version: ${version}/" config/building/snapcraft.yaml
 npm install
 npm run build
-npm run pack
+npm run release
+chmod +x scripts/snap/*.sh
+mkdir snap
+mv scripts/snap/gui snap
+mv config/building/snapcraft.yaml snap
 cp scripts/snap/*.sh dist/linux-unpacked
-snapcraft
+snapcraft --verbose
+

--- a/src/frontend/components/show/TextEditor.svelte
+++ b/src/frontend/components/show/TextEditor.svelte
@@ -8,6 +8,7 @@
     import { formatText } from "./formatTextEditor"
     import { getPlainEditorText } from "./getTextEditor"
     import Notes from "./tools/Notes.svelte"
+    import { transposeText } from "../../utils/chordTranspose"
 
     export let currentShow: any
 
@@ -20,6 +21,14 @@
         if (e.target.closest(".zoom_container") || e.target.closest("button")) return
 
         zoomOpened = false
+    }
+
+    // Transpose handlers
+    function transposeUp() {
+        text = transposeText(text, 1)
+    }
+    function transposeDown() {
+        text = transposeText(text, -1)
     }
 
     // shortcut
@@ -40,6 +49,15 @@
 </script>
 
 <svelte:window on:mousedown={mousedown} on:wheel={wheel} />
+
+<div class="transpose-toolbar">
+    <Button class="transpose-btn" on:click={transposeUp} title="Transpose Up">
+        <Icon id="arrow_up" />
+    </Button>
+    <Button class="transpose-btn" on:click={transposeDown} title="Transpose Down">
+        <Icon id="arrow_down" />
+    </Button>
+</div>
 
 <Notes disabled={currentShow?.locked} style="padding: 30px;height: calc(100% - 28px);font-size: {$textEditZoom / 8}em;" placeholder={getQuickExample()} value={text} on:change={(e) => formatText(e.detail)} />
 
@@ -70,6 +88,28 @@
 </div>
 
 <style>
+    .transpose-toolbar {
+        position: absolute;
+        top: 0;
+        right: 0;
+        display: flex;
+        gap: 6px;
+        z-index: 10;
+        padding: 8px 8px 0 0;
+    }
+    .transpose-btn {
+        min-width: 28px;
+        min-height: 28px;
+        padding: 0;
+        background: var(--primary-darkest);
+        border-radius: 50%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+    .transpose-btn :global(svg) {
+        font-size: 1.3em;
+    }
     .actions {
         position: absolute;
         bottom: 0;

--- a/src/frontend/utils/chordTranspose.ts
+++ b/src/frontend/utils/chordTranspose.ts
@@ -1,0 +1,57 @@
+// src/frontend/utils/chordTranspose.ts
+
+// Standard chromatic scale with sharps
+const SHARP_SCALE = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+// Standard chromatic scale with flats
+const FLAT_SCALE = ["C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"];
+
+// Map for enharmonic equivalents
+const ENHARMONIC: Record<string, string> = {
+    "Db": "C#", "Eb": "D#", "Gb": "F#", "Ab": "G#", "Bb": "A#",
+    "C#": "Db", "D#": "Eb", "F#": "Gb", "G#": "Ab", "A#": "Bb"
+};
+
+function normalizeRoot(root: string, preferSharps: boolean): string {
+    // Always convert to sharp or flat
+    if (preferSharps && FLAT_SCALE.includes(root)) return ENHARMONIC[root] || root;
+    if (!preferSharps && SHARP_SCALE.includes(root)) return ENHARMONIC[root] || root;
+    return root;
+}
+
+function transposeChord(chord: string, step: number, preferSharps = true): string {
+    const match = chord.match(/^([A-G][b#]?)(.*)$/);
+    if (!match) return chord;
+    let [ , root, rest ] = match;
+    // Normalize to sharp or flat
+    root = normalizeRoot(root, preferSharps);
+    const scale = preferSharps ? SHARP_SCALE : FLAT_SCALE;
+    let i = scale.indexOf(root);
+    // If not found, try enharmonic equivalent
+    if (i === -1 && ENHARMONIC[root]) {
+        root = ENHARMONIC[root];
+        i = scale.indexOf(root);
+    }
+    if (i === -1) return chord;
+    let newIndex = (i + step + 12) % 12;
+    return scale[newIndex] + rest;
+}
+
+function transposeFullChord(chord: string, step: number, preferSharps = true): string {
+    // Handles slash chords and chords with bass notes
+    // e.g., Bm7/E, C#/G#, etc.
+    if (chord.includes('/')) {
+        const [main, bass] = chord.split('/');
+        return transposeChord(main, step, preferSharps) + '/' + transposeChord(bass, step, preferSharps);
+    }
+    return transposeChord(chord, step, preferSharps);
+}
+
+export function transposeText(text: string, step: number): string {
+    // Prefer sharps when transposing up, flats when down
+    const preferSharps = step >= 0;
+    // Regex matches chords in brackets, with optional slash chords and modifiers
+    return text.replace(/\[([A-G][b#]?m?(?:aug|dim|sus|add)?\d*(?:\/[A-G][b#]?)?)\]/g, (_unused, p1) => {
+        return '[' + transposeFullChord(p1, step, preferSharps) + ']';
+    });
+}
+

--- a/src/frontend/values/icons.ts
+++ b/src/frontend/values/icons.ts
@@ -22,6 +22,7 @@ const icons: { [key: string]: string } = {
     unmaximized: '<path d="M0 0h24v24H0z" fill="none"/><path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z"/>',
     save: '<path d="M0 0h24v24H0z" fill="none"/><path d="M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z"/>',
     arrow_right: '<path d="M10 17l5-5-5-5v10z"/><path d="M0 24V0h24v24H0z" fill="none"/>',
+    arrow_up: '<path d="M7 14l5-5 5 5z"/><path d="M0 24V0h24v24H0z" fill="none"/>',
     arrow_down: '<path d="M0 0h24v24H0z" fill="none"/><path d="M7 10l5 5 5-5z"/>',
 
     fix_misspelling:


### PR DESCRIPTION
I have gotten the transpose function to work within the text editor, but the save functionality has always been weird and still doesn't work. In production, the save feature often skips small changes such as chord placement, so it might need a revisit.