### PR TITLE
fix 'source' in snapcraft.yaml

### DIFF
--- a/config/building/snapcraft.yaml
+++ b/config/building/snapcraft.yaml
@@ -32,7 +32,7 @@ layout:
         bind: $SNAP/usr/share/alsa
 parts:
     freeshow:
-        source: ../../dist/linux-unpacked/
+        source: dist/linux-unpacked/
         plugin: dump
         stage-packages:
             - libasound2t64


### PR DESCRIPTION
Since `snapcraft` must be run from the root and since `snapcraft.yaml` must be in the `snap` directory of the root (accommodated by the `makesnap` script), the double-parent sourcing should not be used.