### PR TITLE
Fix authentication flow when user has old refresh token

### DIFF
--- a/src/electron/IPC/responsesMain.ts
+++ b/src/electron/IPC/responsesMain.ts
@@ -292,13 +292,13 @@ function getScreens(type: "window" | "screen" = "screen"): Promise<{ name: strin
         OutputHelper.getAllOutputs().forEach((output) => {
             if (output.window) windows.push(output.window)
         })
-        ;[mainWindow!, ...windows].forEach((window) => {
-            const mediaId = window?.getMediaSourceId()
-            const windowsAlreadyExists = sources.find((a) => a.id === mediaId)
-            if (windowsAlreadyExists) return
+            ;[mainWindow!, ...windows].forEach((window) => {
+                const mediaId = window?.getMediaSourceId()
+                const windowsAlreadyExists = sources.find((a) => a.id === mediaId)
+                if (windowsAlreadyExists) return
 
-            screens.push({ name: window?.getTitle(), id: mediaId })
-        })
+                screens.push({ name: window?.getTitle(), id: mediaId })
+            })
 
         return screens
     }

--- a/src/electron/chums/ChumsConnect.ts
+++ b/src/electron/chums/ChumsConnect.ts
@@ -76,7 +76,7 @@ export class ChumsConnect {
         return new Promise((resolve) => {
             const apiUrl = data.api === "doing" ? DOING_API_URL : CONTENT_API_URL
             const headers = data.authenticated ? { Authorization: `Bearer ${CHUMS_ACCESS.access_token}` } : {}
-            //console.log("SENDING REQUEST TO CHUMS", apiUrl, data.endpoint, data.method || "GET", headers, data.data || {})
+            // console.log("SENDING REQUEST TO CHUMS", apiUrl, data.endpoint, data.method || "GET", headers, data.data || {})
             httpsRequest(apiUrl, data.endpoint, data.method || "GET", headers, data.data || {}, (err, result) => {
                 if (err) {
                     console.error("Could not get data", apiUrl, data.endpoint)

--- a/src/electron/data/export.ts
+++ b/src/electron/data/export.ts
@@ -146,7 +146,7 @@ ipcMain.on(EXPORT, (_e, msg: any) => {
 
 // ----- JSON -----
 
-export function exportJSON(content: any, extension: string, path: string, name: string = "") {
+export function exportJSON(content: any, extension: string, path: string, name = "") {
     writeFile(join(path, name || content.name || "Unnamed"), extension, JSON.stringify(content, null, 4), "utf-8", (err) => doneWritingFile(err, path))
 }
 

--- a/src/electron/data/import.ts
+++ b/src/electron/data/import.ts
@@ -264,18 +264,18 @@ function extractZipDataAndMedia(filePath: string, importFolder: string) {
     // write files
     const replacedMedia: { [key: string]: string } = {}
     dataContent.files?.forEach((rawPath: string) => {
-        const filePath = path.normalize(rawPath)
+        const currentPath = path.normalize(rawPath)
 
         // check if path already exists on the system
-        if (doesPathExist(filePath)) return
+        if (doesPathExist(currentPath)) return
 
-        const fileName = path.basename(filePath)
+        const fileName = path.basename(currentPath)
         const file = zipData.find((a) => a.name === fileName)?.content
 
         // get file path hash to prevent the same file importing multiple times
         // this also ensures files with the same name don't get overwritten
         const ext = path.extname(fileName)
-        const pathHash = `${path.basename(filePath, ext)}_${filePathHashCode(filePath)}${ext}`
+        const pathHash = `${path.basename(currentPath, ext)}_${filePathHashCode(currentPath)}${ext}`
         const newMediaPath = path.join(importFolder, pathHash)
 
         if (!file) return

--- a/src/electron/planningcenter/request.ts
+++ b/src/electron/planningcenter/request.ts
@@ -19,6 +19,7 @@ type PCORequestData = {
 export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any> {
     const MAX_RETRIES = 3
     const PCO_ACCESS = await pcoConnect(data.scope)
+
     if (!PCO_ACCESS) {
         sendToMain(ToMain.ALERT, "Not authorized at Planning Center (try logging out and in again)!")
         return null
@@ -88,7 +89,11 @@ export async function pcoLoadServices(dataPath: string) {
         endpoint: typesEndpoint
     })
 
-    if (!SERVICE_TYPES[0]?.id) return
+    if (!SERVICE_TYPES || !SERVICE_TYPES[0]?.id) {
+        sendToMain(ToMain.ALERT, "No service types found in Planning Center! Please create some services first.")
+        return
+    }
+
     sendToMain(ToMain.TOAST, "Getting schedules from Planning Center")
 
     const projects: any[] = []
@@ -107,7 +112,10 @@ export async function pcoLoadServices(dataPath: string) {
                 }
             })
 
-            if (!SERVICE_PLANS[0]?.id) return
+            if (!SERVICE_PLANS || !SERVICE_PLANS[0]?.id) {
+                console.warn(`No plans found for service type ${serviceType.attributes.name} (${serviceType.id})`)
+                return
+            }
 
             // Now we only need to filter for the one week window since we're already getting future plans
             const filteredPlans = SERVICE_PLANS.filter(({ attributes: a }: any) => {

--- a/src/electron/utils/keys.ts
+++ b/src/electron/utils/keys.ts
@@ -5,7 +5,7 @@
 // (they are all free, so you can just get your own keys if you want)
 
 export function getKey(type: string) {
-    if (type === "pco_id") return decrypt("43560b570154400d5752490759510806175a0950140658550001400a09074001575700564a0a5d5844570d570106470c5d0414055f55565d105d5c0012005f53")
+    if (type === "pco_id") return "35d1112d839d678ce3f1de730d2cff0b81038c2944b11c5e2edf03f8b43abc05"
     if (type === "chums_id") return decrypt("1e2608317f261819055200")
     if (type === "chums_secret") return decrypt("02022a207f57193d5f2d13")
     return "5a4104165513101501415e5b030a5d19121f03485f4603035a03"

--- a/src/electron/utils/requests.ts
+++ b/src/electron/utils/requests.ts
@@ -12,10 +12,10 @@ export function httpsRequest(hostname: string, path: string, method: "POST" | "G
         headers: {
             ...(dataString.length
                 ? {
-                      "Content-Type": "application/json",
-                      "User-Agent": "Node.js",
-                      "Content-Length": Buffer.byteLength(dataString),
-                  }
+                    "Content-Type": "application/json",
+                    "User-Agent": "Node.js",
+                    "Content-Length": Buffer.byteLength(dataString),
+                }
                 : {}),
             ...headers,
         },
@@ -66,7 +66,7 @@ export function httpsRequest(hostname: string, path: string, method: "POST" | "G
             ...createLog(err),
             type: "Failed HTTPS Request",
             source: hostname + path,
-            message: err.message.toString() + "\n" + JSON.stringify(content || {}),
+            message: String(err.message) + "\n" + JSON.stringify(content || {}),
         }
 
         logError(error, "request")


### PR DESCRIPTION
Will now start the normal Planning Center authentication flow when the refresh token call fails.

Was trying to debug another issue with FreeShow, but Planning Center wouldn't authenticate. Debugged it and figured this could be a solution. Sorry for the accidental formatting changes.