### PR TITLE
Fix TypeError when dynamicRSS is undefined in getDynamicIds

### DIFF
--- a/src/frontend/components/helpers/showActions.ts
+++ b/src/frontend/components/helpers/showActions.ts
@@ -1025,7 +1025,7 @@ export function getDynamicIds(noVariables = false) {
     const variableValues = variablesList.map(({ name }) => `$` + getVariableNameId(name))
     const variableSetNameValues = variablesList.filter((a) => a.type === "random_number" && (a.sets?.length || 0) > 1).map(({ name }) => `variable_set_` + getVariableNameId(name))
 
-    const rssValues = get(special).dynamicRSS?.map(({ name }) => `rss_` + getVariableNameId(name))
+    const rssValues = get(special).dynamicRSS?.map(({ name }) => `rss_` + getVariableNameId(name)) || []
 
     const mergedValues = [...mainValues, ...metaValues]
     if (rssValues.length) mergedValues.push(...rssValues)


### PR DESCRIPTION
Resolves error: "Cannot read properties of undefined (reading 'length')" when get(special).dynamicRSS is undefined by ensuring rssValues is always an array using nullish coalescing operator.

Looks like It fixes this error: https://github.com/ChurchApps/FreeShow/issues/1763