### PR TITLE
implemented option to customise the auto font sizing delay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2024,20 +2024,6 @@
         "win32"
       ]
     },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.44.1.tgz",
-      "integrity": "sha512-J8o22LuF0kTe7m+8PvW9wk3/bRq5+mRo5Dqo6+vXb7otCm3TPhYOJqOaQtGU9YMWQSL3krMnoOxMr0+9E6F3Ug==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",

--- a/public/lang/en_GB.json
+++ b/public/lang/en_GB.json
@@ -1389,6 +1389,7 @@
         "in": "In",
         "out": "Out",
         "duration": "Duration",
+        "autoSizeDelay": "Auto Font Sizing Delay",
         "easing": "Easing",
         "direction": "Direction",
         "type": "Type",

--- a/src/electron/data/defaults.ts
+++ b/src/electron/data/defaults.ts
@@ -64,7 +64,7 @@ export const defaultSettings: { [key in SaveListSettings]: any } = {
     splitLines: 0,
     theme: "default",
     transitionData: {
-        text: { type: "fade", duration: 500, easing: "sine" },
+        text: { type: "fade", duration: 500, easing: "sine", autoSizeDelay: 500 },
         media: { type: "fade", duration: 800, easing: "sine" }
     },
     volume: 1,

--- a/src/frontend/components/actions/api.ts
+++ b/src/frontend/components/actions/api.ts
@@ -135,6 +135,7 @@ export type API_transition = {
     id?: "text" | "media" // default: "text"
     type?: TransitionType // default: "fade"
     duration?: number // default: 500
+    autoSizeDelay? : number
     easing?: string // default: "sine"
 }
 export type API_variable = {

--- a/src/frontend/components/main/popups/Transition.svelte
+++ b/src/frontend/components/main/popups/Transition.svelte
@@ -31,8 +31,8 @@
 
     // UPDATE
 
-    function changeTransition(id: TransitionTypes, key: "type" | "duration" | "easing" | "custom", value: any, reset = false) {
-        if (key === "duration") value = Number(value)
+    function changeTransition(id: TransitionTypes, key: "type" | "duration" | "easing" | "autoSizeDelay" | "custom", value: any, reset = false) {
+        if (key === "duration" || key === "autoSizeDelay") value = Number(value)
 
         if (isItem) {
             // WIP duplicate of SetTime.svelte ++
@@ -100,7 +100,7 @@
 
     let updated: string[] = []
     let updatedTimeout: NodeJS.Timeout | null = null
-    function updateSpecific(data: Transition, key: "type" | "duration" | "easing" | "custom", value: any, reset = false) {
+    function updateSpecific(data: Transition, key: "type" | "duration" | "easing" | "autoSizeDelay" | "custom", value: any, reset = false) {
         if (!enableSpecific) {
             return { ...data, [key]: value }
         }
@@ -197,6 +197,7 @@
 
     $: isDisabled = currentTransition.type === "none"
     $: durationValue = currentTransition.duration
+    $: autoSizeDelayValue = currentTransition.autoSizeDelay
     $: easingValue = easings.find((a) => a.id === currentTransition.easing)?.name || "$:easings.sine:$"
 
     // SPECIFIC
@@ -293,6 +294,11 @@
 <CombinedInput style="margin-top: 10px;">
     <p><T id="transition.duration" /></p>
     <NumberInput disabled={isDisabled} value={durationValue} max={20000} fixed={1} decimals={3} step={100} inputMultiplier={0.001} on:change={(e) => changeTransition(selectedType, "duration", e.detail)} />
+</CombinedInput>
+
+<CombinedInput>
+    <p><T id="transition.autoSizeDelay" /></p>
+    <NumberInput disabled={isDisabled} value={autoSizeDelayValue} max={20000} fixed={2} decimals={3} step={100} inputMultiplier={0.001} on:change={(e) => changeTransition(selectedType, "autoSizeDelay", e.detail)} />
 </CombinedInput>
 
 <CombinedInput>

--- a/src/frontend/components/output/transitions/SlideItemTransition.svelte
+++ b/src/frontend/components/output/transitions/SlideItemTransition.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
+    import { get } from "svelte/store"
     import { uid } from "uid"
     import type { Item, Transition } from "../../../../types/Show"
-    import { currentWindow, scriptureSettings, templates } from "../../../stores"
+    import { currentWindow, scriptureSettings, templates, transitionData } from "../../../stores"
     import { clone } from "../../helpers/array"
     import { getStyleTemplate, slideHasAutoSizeItem } from "../../helpers/output"
     import OutputTransition from "./OutputTransition.svelte"
+
     // import { onMount } from "svelte"
 
     export let globalTransition: Transition
@@ -57,7 +59,7 @@
             if (!Object.keys(customTemplate).length && outSlide?.id === "temp") customTemplate = $templates[$scriptureSettings.template] || {}
 
             // wait output style/scripture template auto size
-            if (Object.keys(customTemplate).length ? slideHasAutoSizeItem(customTemplate) : item.auto) outDelay = 500
+            if (Object.keys(customTemplate).length ? slideHasAutoSizeItem(customTemplate) : item.auto) outDelay = get(transitionData)?.text.autoSizeDelay || 500
 
             if (!inDelay) inDelay = outDelay * 0.98
         }

--- a/src/frontend/stores.ts
+++ b/src/frontend/stores.ts
@@ -192,7 +192,7 @@ export const textCache: Writable<any> = writable({}) // {}
 export const groups: Writable<ShowGroups> = writable({}) // {default}
 export const categories: Writable<Categories> = writable({}) // {default}
 export const transitionData: Writable<{ text: Transition; media: Transition }> = writable({
-    text: { type: "fade", duration: 500, easing: "sine" },
+    text: { type: "fade", duration: 500, easing: "sine", autoSizeDelay: 500 },
     media: { type: "fade", duration: 800, easing: "sine" }
 }) // {default}
 export const slidesOptions: Writable<SlidesOptions> = writable({ columns: 4, mode: "grid" }) // {default}

--- a/src/frontend/utils/transitions.ts
+++ b/src/frontend/utils/transitions.ts
@@ -83,6 +83,7 @@ export function updateTransition(data: API_transition) {
         a[data.id || "text"] = {
             type: data.type || "fade",
             duration: data.duration ?? 500,
+            autoSizeDelay: data.autoSizeDelay ?? 500,
             easing: data.easing || "sine",
         }
 

--- a/src/types/Show.ts
+++ b/src/types/Show.ts
@@ -333,6 +333,7 @@ export interface SlideAction {
 export interface Transition {
     type: TransitionType
     duration: number
+    autoSizeDelay?: number
     easing: string
     delay?: number // item in/out wait
     custom?: any // e.g. transition direction


### PR DESCRIPTION
The auto font sizing delay was too much for our workflow so I have added an option to customise it within the transition menu as other workflows might not care about it. However this may a little too confusing for some users so it may be better to keep this hidden within advanced/other settings.

Also let me know if my implementation is a little inefficient, while this does work I do believe adding another option within the other settings tab and updating the value in the autoSizeDelay store would suffice.

![Screenshot_20250707_201557](https://github.com/user-attachments/assets/313b3b92-fc9a-4979-b534-5e8a0cb96679)
