### PR TITLE
Add optional sequencing for Planning Center sections and normalize line endings

### DIFF
--- a/src/electron/planningcenter/request.ts
+++ b/src/electron/planningcenter/request.ts
@@ -291,8 +291,6 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
         sections = getOrderedSections(sections, sequence)
     }
 
-    console.debug("Song sequence:", sequence)
-
     const show = getShow(songData, song, sections)
     const showId = `pcosong_${songData.id}`
 

--- a/src/electron/planningcenter/request.ts
+++ b/src/electron/planningcenter/request.ts
@@ -18,6 +18,12 @@ type PCORequestData = {
     params?: Record<string, string> // Add params type
 }
 
+type SongSection = {
+    label: string,
+    lyrics: string,
+    breaks_at?: number
+}
+
 interface ServiceType {
     id: string
     attributes: {
@@ -270,14 +276,22 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
     const song = songArrangement.attributes
     const sequence = item.custom_arrangement_sequence || song.sequence || []
 
-    let sections = (await pcoRequest({
+    let sections: SongSection[] = (await pcoRequest({
         scope: "services",
         endpoint: `${arrangementEndpoint}/${songArrangement.id}/sections`
     }))[0]?.attributes.sections || []
 
     if (!sections.length) {
         sections = sequence.map((id: any) => ({ label: id, lyrics: "" }))
+    } else {
+        sections = sections.map(normalizeSongSection)
     }
+
+    if (sequence.length && sections.length) {
+        sections = getOrderedSections(sections, sequence)
+    }
+
+    console.debug("Song sequence:", sequence)
 
     const show = getShow(songData, song, sections)
     const showId = `pcosong_${songData.id}`
@@ -286,6 +300,33 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
         show: { id: showId, ...show },
         projectItem: { type: "show", id: showId, scheduleLength: item.attributes.length }
     }
+}
+
+function getOrderedSections(sections: SongSection[], sequence: any[]): SongSection[] {
+    const sectionMap: { [key: string]: SongSection } = {}
+    sections.forEach((section) => {
+        sectionMap[section.label] = section
+    })
+
+    const orderedSections: SongSection[] = []
+    sequence.forEach((label) => {
+        if (sectionMap[label]) {
+            orderedSections.push(sectionMap[label])
+        }
+    })
+
+    return orderedSections
+}
+
+function normalizeSongSection(section: SongSection): SongSection {
+    return {
+        ...section,
+        lyrics: normalizeLineBreaks(section.lyrics)
+    }
+}
+
+function normalizeLineBreaks(text: string): string {
+    return text.replace(/\n\r/g, "\n").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 }
 
 function processRegularItem(item: ProjectItem) {


### PR DESCRIPTION
- Ensures consistent line endings.
- Use Planning Center sequence (when available) to create section slides in the order of the arrangement.

Preview of what it does:
<img width="1919" height="1079" alt="clipboard_2025-08-27_20-35" src="https://github.com/user-attachments/assets/c43e86f2-5eb7-4c10-856e-8a125e40459b" />

Planning Center requires unique labels for sections, that’s why FreeShow auto increments these to `Verse 2 1` and `Verse 2 2`.