### PR TITLE
Multiple same type actions

### DIFF
--- a/src/frontend/components/actions/actions.ts
+++ b/src/frontend/components/actions/actions.ts
@@ -175,8 +175,12 @@ export function addSlideAction(slideIndex: number, actionId: string, actionValue
 
     const action = { id, triggers: [actionId], actionValues }
 
+    // Check if this action type can have multiple instances
+    const data = actionData[actionId]
+    const canAddMultiple = data?.canAddMultiple || allowMultiple
+
     const existingIndex = slideActions.slideActions.findIndex((a) => a.triggers?.[0] === actionId)
-    if (allowMultiple || existingIndex < 0) slideActions.slideActions.push(action)
+    if (canAddMultiple || existingIndex < 0) slideActions.slideActions.push(action)
     else slideActions.slideActions[existingIndex] = action
 
     history({ id: "SHOW_LAYOUT", newData: { key: "actions", data: slideActions, indexes: [slideIndex] } })


### PR DESCRIPTION
- Modified dropActions.ts to respect canAddMultiple setting and only replace actions with identical values
- Updated Action.svelte findExisting() to not auto-replace actions that support multiple instances
- Enhanced addSlideAction() in actions.ts to use canAddMultiple from actionData
- Improved createSlideAction() consistency for canAddMultiple handling

Now users can add multiple 'change_stage_output_layout' actions (and other canAddMultiple actions) to a single function/slide, enabling complex workflows like switching between multiple stage layouts sequentially.