### PR TITLE
Fix spacing in transition dialog text

### DIFF
--- a/src/frontend/components/main/popups/Transition.svelte
+++ b/src/frontend/components/main/popups/Transition.svelte
@@ -198,8 +198,8 @@
 
     type TransitionTypes = "text" | "media"
     const transitionTabs = {
-        text: { id: "text", name: translateText("transition.text") + (isSlide ? translateText("transition.current_slide") : ""), icon: "text" },
-        media: { id: "media", name: translateText("transition.media") + (isSlide ? translateText("transition.current_slide") : ""), icon: "image" }
+        text: { id: "text", name: translateText("transition.text") + (isSlide ? " " + translateText("transition.current_slide") : ""), icon: "text" },
+        media: { id: "media", name: translateText("transition.media") + (isSlide ? " " + translateText("transition.current_slide") : ""), icon: "image" }
     }
     let selectedType: TransitionTypes = "text"
 


### PR DESCRIPTION
- Add missing space between 'Text transition' and 'for current slide'
- Add missing space between 'Media transition' and 'for current slide'
- Fixes issue where text displayed as 'Text transitionfor current slide'

Fixes #2088