### PR TITLE
Protect Bible text from accidental edits (scripture shows read-only by default)

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -999,6 +999,8 @@
     },
     "edit": {
         "text": "Text",
+        "unlock_scripture_text": "Unlock scripture text",
+        "unlock_scripture_text_tip": "Allow editing the protected Bible text in this show",
         "font": "Font",
         "family": "Font family",
         "font_size": "Font size",
@@ -1352,6 +1354,7 @@
         "next_item_on_last_slide": "Arrow left/right changes project item on first/last slide",
         "slide_number_keys": "Play slides with number keys",
         "auto_shortcut_first_letter": "Auto shortcut to first letter in text",
+        "protect_scripture_text": "Protect Bible text from editing",
         "startup_projects_list": "Show the projects list on startup",
         "auto_output": "Activate output screen on startup",
         "hide_cursor_in_output": "Hide cursor in output",

--- a/src/frontend/components/actions/api.ts
+++ b/src/frontend/components/actions/api.ts
@@ -18,6 +18,7 @@ import { pauseAllTimers } from "../drawer/timers/timers"
 import { getSlideThumbnail, getThumbnail } from "../helpers/media"
 import { changeStageOutputLayout, startCamera, startScreen, startStreaming, stopStreaming, toggleOutputs } from "../helpers/output"
 import { OutputHelper } from "../helpers/OutputHelper"
+import { isScriptureTextLocked } from "../helpers/scriptureProtection"
 import { changeOutputStyle, playSlideTimers, randomSlide, replaceDynamicValues, selectProjectShow, sendMidi, startShowSync } from "../helpers/showActions"
 import { startTimerById, startTimerByName, stopTimers } from "../helpers/timerTick"
 import { muteOutput, unmuteOutput } from "../helpers/video"
@@ -213,7 +214,10 @@ export const API_ACTIONS = {
     start_show: (data: API_id) => startShowSync(data.id),
     change_layout: (data: API_layout) => changeShowLayout(data),
     set_plain_text: (data: API_id_value) => formatText(data.value, data.id),
-    set_show: (data: API_id_value) => setShowAPI(data.id, data.value),
+    set_show: (data: API_id_value) => {
+        if (isScriptureTextLocked(data.id)) return
+        setShowAPI(data.id, data.value)
+    },
     rearrange_groups: (data: API_rearrange) => rearrangeGroups(data),
     add_group: (data: API_group) => addGroup(data),
     set_template: (data: API_id) => setTemplate(data.id),

--- a/src/frontend/components/context/menuClick.ts
+++ b/src/frontend/components/context/menuClick.ts
@@ -99,6 +99,7 @@ import { clone, removeDuplicates, sortObjectNumbers } from "../helpers/array"
 import { copy, cut, deleteAction, duplicate, paste, selectAll } from "../helpers/clipboard"
 import { history, redo, undo } from "../helpers/history"
 import { getExtension, getFileName, getMediaLayerType, getMediaStyle, getMediaType, removeExtension, splitPath } from "../helpers/media"
+import { isScriptureTextLocked } from "../helpers/scriptureProtection"
 import { defaultOutput, getCurrentStyle, getFirstActiveOutput, setOutput, toggleOutput, toggleOutputs } from "../helpers/output"
 import { select } from "../helpers/select"
 import { bindSlidesToOutput, checkName, formatToFileName, getLayoutRef, openShow, removeTemplatesFromShow, updateShowsList } from "../helpers/show"
@@ -2123,6 +2124,12 @@ export async function format(id: string, obj: ObjData, data: any = null) {
 
     const editing = get(activeEdit)
     const items = editing.items || []
+
+    // SCRIPTURE TEXT PROTECTION: block text formatting / find & replace on protected Bible text
+    if ((editing.type || "show") === "show" && isScriptureTextLocked(get(activeShow)?.id)) {
+        newToast("output.state_locked")
+        return
+    }
 
     // WIP let slide = getEditSlide()
 

--- a/src/frontend/components/edit/EditHeader.svelte
+++ b/src/frontend/components/edit/EditHeader.svelte
@@ -78,6 +78,20 @@
                     <p><T id="timeline.toggle_timeline" /></p>
                 </MaterialButton>
 
+                {#if currentShow?.reference?.type === "scripture" && $special.protectScriptureText !== false}
+                    <div class="DIVIDER"></div>
+
+                    <MaterialButton title="edit.unlock_scripture_text_tip" on:click={() => _show(showId).set({ key: "unlockedScriptureText", value: !currentShow?.unlockedScriptureText })}>
+                        <Icon id="lock" white={!currentShow?.unlockedScriptureText} />
+
+                        {#if currentShow?.unlockedScriptureText}
+                            <Icon id="check" size={0.7} white />
+                        {/if}
+
+                        <p><T id="edit.unlock_scripture_text" /></p>
+                    </MaterialButton>
+                {/if}
+
                 <!-- <div class="DIVIDER"></div> -->
 
                 <!-- lock slide group from here? -->

--- a/src/frontend/components/edit/editbox/Editbox.svelte
+++ b/src/frontend/components/edit/editbox/Editbox.svelte
@@ -178,6 +178,8 @@
     let profile = getAccess("shows")
     $: currentSlide = (ref.type || "show") === "show" ? $showsCache[active || ""]?.slides?.[ref.id] : null // WIP get group slide
     $: isLocked = (ref.type || "show") !== "show" ? false : $showsCache[active || ""]?.locked || currentSlide?.locked || profile.global === "read" || profile[$showsCache[active || ""]?.category || ""] === "read"
+    // SCRIPTURE TEXT PROTECTION: Bible-sourced verse text is read-only unless protection is globally off or this show was explicitly unlocked
+    $: scriptureTextLocked = (ref.type || "show") === "show" && $showsCache[active || ""]?.reference?.type === "scripture" && $special.protectScriptureText !== false && !$showsCache[active || ""]?.unlockedScriptureText
 
     // give CSS access to number variable values
     $: cssVariables = getNumberVariables($variables)
@@ -217,7 +219,7 @@ bind:offsetWidth={width} -->
         <EditboxPlain {item} {index} {ratio} hideMovebox={cropActive} />
     {/if}
     {#if item?.lines && !noTextMode}
-        <EditboxLines {item} {ref} {index} {editIndex} {plain} {chordsMode} {chordsAction} {isLocked} />
+        <EditboxLines {item} {ref} {index} {editIndex} {plain} {chordsMode} {chordsAction} isLocked={isLocked || scriptureTextLocked} />
     {:else if previewItem}
         {#if previewItem.type === "media"}
             <div class="mediaFrame" class:showOverflow={cropActive}>

--- a/src/frontend/components/helpers/scriptureProtection.ts
+++ b/src/frontend/components/helpers/scriptureProtection.ts
@@ -1,0 +1,13 @@
+import { get } from "svelte/store"
+import { showsCache, special } from "../../stores"
+
+// A Bible-sourced show's verse text is protected (read-only) when global scripture
+// protection is enabled and the show hasn't been explicitly unlocked. Used to gate the
+// imperative text-mutation paths (format actions, find & replace, API text setters) so
+// they can't alter downloaded/API scripture. Styling/layout are intentionally NOT gated.
+export function isScriptureTextLocked(showId: string | undefined | null): boolean {
+    if (!showId) return false
+    const show = get(showsCache)[showId]
+    if (show?.reference?.type !== "scripture") return false
+    return get(special).protectScriptureText !== false && !show.unlockedScriptureText
+}

--- a/src/frontend/components/settings/tabs/General.svelte
+++ b/src/frontend/components/settings/tabs/General.svelte
@@ -54,5 +54,8 @@
 <MaterialToggleSwitch label="settings.slide_number_keys" checked={$special.numberKeys} defaultValue={false} on:change={(e) => updateSpecial(e.detail, "numberKeys")} />
 <MaterialToggleSwitch label="settings.auto_shortcut_first_letter" checked={$special.autoLetterShortcut} defaultValue={false} on:change={(e) => updateSpecial(e.detail, "autoLetterShortcut")} />
 
+<!-- scripture: -->
+<MaterialToggleSwitch label="settings.protect_scripture_text" checked={$special.protectScriptureText !== false} defaultValue={true} on:change={(e) => updateSpecial(e.detail, "protectScriptureText", true)} />
+
 <!-- when disabled: no ./F2 to clear, F5 clears slide timer instead of next slide, no PageUp/PageDown/Home/End for slide navigation -->
 <!-- <Checkbox checked={$special.disablePresenterControllerKeys} on:change={(e) => updateSpecial(e.target.checked, "disablePresenterControllerKeys")} /> -->

--- a/src/frontend/components/show/TextEditor.svelte
+++ b/src/frontend/components/show/TextEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { Show } from "../../../types/Show"
     import { getQuickExample } from "../../converters/txt"
-    import { activePopup, textEditActive, textEditZoom } from "../../stores"
+    import { activePopup, special, textEditActive, textEditZoom } from "../../stores"
     import { transposeText } from "../../utils/chordTranspose"
     import { newToast } from "../../utils/common"
     import Icon from "../helpers/Icon.svelte"
@@ -18,7 +18,9 @@
     $: if (currentShow) text = getPlainEditorText()
 
     $: hasLockedSlide = Object.values(currentShow?.slides || {}).some((a) => a?.locked)
-    $: isLocked = currentShow?.locked || hasLockedSlide
+    // SCRIPTURE TEXT PROTECTION: also lock the plain-text editor for Bible-sourced shows (matches the editbox gate)
+    $: scriptureTextLocked = currentShow?.reference?.type === "scripture" && $special.protectScriptureText !== false && !currentShow?.unlockedScriptureText
+    $: isLocked = currentShow?.locked || hasLockedSlide || scriptureTextLocked
     $: if (isLocked) newToast("output.state_locked")
 
     // Ctrl+F in shortcuts.ts does not get triggered when a text input is active, so we trigger from here as well

--- a/src/frontend/components/show/formatTextEditor.ts
+++ b/src/frontend/components/show/formatTextEditor.ts
@@ -8,11 +8,14 @@ import { getItemText, getSlideText } from "../edit/scripts/textStyle"
 import { clone, keysToID, removeDuplicates } from "../helpers/array"
 import { history } from "../helpers/history"
 import { isEmpty } from "../helpers/output"
+import { isScriptureTextLocked } from "../helpers/scriptureProtection"
 import { getGlobalGroup } from "../helpers/show"
 import { _show } from "../helpers/shows"
 
 export function formatText(text: string, showId = "") {
     if (!showId) showId = get(activeShow)?.id || ""
+    // SCRIPTURE TEXT PROTECTION: don't let a plain-text/transpose rebuild overwrite protected Bible text
+    if (isScriptureTextLocked(showId)) return
     const show: Show = clone(_show(showId).get())
     if (!show) return
 

--- a/src/types/Show.ts
+++ b/src/types/Show.ts
@@ -13,6 +13,7 @@ export interface Show {
     origin?: string // "pco" | "churchApps" | "hymnary", etc.
     private?: boolean // hide from drawer
     locked?: boolean // disable edits
+    unlockedScriptureText?: boolean // allow editing Bible-sourced verse text even when "protect scripture text" is on
     category: null | ID
     quickAccess?: any
     reference?: {


### PR DESCRIPTION
Adds an opt-out safeguard so downloaded/API Bible text can't be silently altered and re-projected as Scripture.

Verse text in Bible-sourced shows (reference.type === "scripture") is read-only by default — styling, layout, templates, and verse-number options stay editable; only the words lock.

Global setting "Protect Bible text from editing" (default on): special.protectScriptureText.
Per-show unlock in the edit-header "⋯" dropdown: show.unlockedScriptureText.
Gated paths (shared isScriptureTextLocked() helper, all respecting the setting + per-show unlock):

inline editbox (EditboxLines read-only render) + plain-text popup (TextEditor disabled);
format actions (capitalize/lowercase/uppercase/trim) + find & replace (format());
the formatText() rebuild (set_plain_text + transpose_show_* API, SlideEditor/TextEditor transpose);
the set_show API.
Structural ops (style/layout, merge/split, paste-slides, delete) stay editable — they don't alter the words. svelte-check 0 errors. 10 files, +56/−4.