### PR TITLE
Show editing fixes: backspace caret jump, style tools, group locks, history/undo

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -570,6 +570,7 @@
     "toast": {
         "saving": "Saving...",
         "saved": "Saved",
+        "autosize_disabled": "Auto size disabled",
         "error_media": "Could not get media.",
         "empty_styles": "No styles",
         "chapter_undefined": "Chapter {} does not exist in this book.",

--- a/src/frontend/components/edit/EditTools.svelte
+++ b/src/frontend/components/edit/EditTools.svelte
@@ -7,7 +7,7 @@
     import T from "../helpers/T.svelte"
     import { clone } from "../helpers/array"
     import { history } from "../helpers/history"
-    import { getLayoutRef } from "../helpers/show"
+    import { getLayoutRef, isSlideLocked } from "../helpers/show"
     import { _show } from "../helpers/shows"
     import { getStyles } from "../helpers/style"
     import FloatingInputs from "../input/FloatingInputs.svelte"
@@ -360,11 +360,7 @@
     let profile = getAccess("shows")
 
     $: currentShow = $showsCache[$activeShow?.id || ""]
-    $: isSlideLockedFn = () => {
-        const slideId = ref[activeSlide]?.parent?.id || ref[activeSlide]?.id
-        return !!currentShow?.slides?.[slideId]?.locked
-    }
-    $: isLocked = activeId ? false : currentShow?.locked || isSlideLockedFn() || profile.global === "read" || profile[currentShow?.category || ""] === "read"
+    $: isLocked = activeId ? false : currentShow?.locked || isSlideLocked($activeShow?.id || "", ref[activeSlide]?.id || "", currentShow) || profile.global === "read" || profile[currentShow?.category || ""] === "read"
     // $: isDefault = $activeEdit.type === "overlay" ? $overlays[activeId || ""]?.isDefault : $activeEdit.type === "template" ? $templates[activeId || ""]?.isDefault : false
     $: overflowHidden = !!(isShow || $activeEdit.type === "template" || $activeEdit.type === "overlay")
 

--- a/src/frontend/components/edit/EditTools.svelte
+++ b/src/frontend/components/edit/EditTools.svelte
@@ -104,7 +104,7 @@
     const getItemsByIndex = (array: number[]): Item[] => array.map((i) => allSlideItems[i])
 
     // select active items or all items
-    $: items = $activeEdit.items.length ? getItemsByIndex($activeEdit.items.sort((a, b) => a - b)) : allSlideItems
+    $: items = $activeEdit.items.length ? getItemsByIndex([...$activeEdit.items].sort((a, b) => a - b)) : allSlideItems
     // select last item
     $: item = items?.length ? items[items.length - 1] : null
 

--- a/src/frontend/components/edit/Slides.svelte
+++ b/src/frontend/components/edit/Slides.svelte
@@ -61,7 +61,7 @@
 
         let index = $activeEdit.slide! - 1
         setTimeout(() => {
-            if (index >= 0 && scrollElem) offset = (scrollElem.querySelector(".grid")?.children?.[index] as HTMLElement)?.offsetTop || 5 - 5
+            if (index >= 0 && scrollElem) offset = ((scrollElem.querySelector(".grid")?.children?.[index] as HTMLElement)?.offsetTop || 5) - 5
         }, 10)
     }
 

--- a/src/frontend/components/edit/editbox/Editbox.svelte
+++ b/src/frontend/components/edit/editbox/Editbox.svelte
@@ -3,6 +3,7 @@
     import { activeEdit, activeShow, openToolsTab, os, outputs, showsCache, special, templates, variables } from "../../../stores"
     import { translateText } from "../../../utils/language"
     import { getAccess } from "../../../utils/profile"
+    import { isSlideLocked } from "../../helpers/show"
     import { isComposing } from "../../../utils/shortcuts"
     import { deleteAction } from "../../helpers/clipboard"
     import { history } from "../../helpers/history"
@@ -208,8 +209,8 @@
     $: isDisabledVariable = item?.type === "variable" && $variables[item.variable?.id]?.enabled === false
     // SHOW IS LOCKED FOR EDITING
     let profile = getAccess("shows")
-    $: currentSlide = (ref.type || "show") === "show" ? $showsCache[active || ""]?.slides?.[ref.id] : null // WIP get group slide
-    $: isLocked = (ref.type || "show") !== "show" ? false : $showsCache[active || ""]?.locked || currentSlide?.locked || profile.global === "read" || profile[$showsCache[active || ""]?.category || ""] === "read"
+    $: isGroupLocked = (ref.type || "show") === "show" ? isSlideLocked(active || "", ref.id, $showsCache) : false
+    $: isLocked = (ref.type || "show") !== "show" ? false : $showsCache[active || ""]?.locked || isGroupLocked || profile.global === "read" || profile[$showsCache[active || ""]?.category || ""] === "read"
 
     // give CSS access to certain dynamic values
     $: cssVariables = createCSSVariables($variables)

--- a/src/frontend/components/edit/editbox/EditboxHelper.ts
+++ b/src/frontend/components/edit/editbox/EditboxHelper.ts
@@ -180,7 +180,8 @@ export class EditboxHelper {
 
             const normalWrap = useNormalWrap || align.includes("justify") || align.includes("left") || JSON.stringify(line).includes("nowrap")
 
-            html += `<div class="break ${normalWrap ? "normalWrap" : ""}" ${plain ? "" : style}>`
+            // plain mode has no style attributes, identity attributes map styles back to the source lines (they are cloned when the browser splits a line)
+            html += `<div class="break ${normalWrap ? "normalWrap" : ""}" ${plain ? `data-line-index="${i}"` : style}>`
 
             // fix removing all text in a line
             if (i === 0 && line.text?.[0]?.style) firstTextStyleArchive = line.text?.[0]?.style || ""
@@ -203,7 +204,7 @@ export class EditboxHelper {
                 // if (value === " ") value = "&nbsp;"
 
                 // this will "hide" any HTML tags if any in the actual text content (not chords or text editor)
-                html += `<span data-freeshow-text="true" class="${a.customType && !a.customType.includes("jw") ? "custom" : ""}" ${plain ? "" : textStyle} data-customtype='${a.customType || ""}' data-sourcedynamickey='${a.sourceDynamicKey || ""}' data-chords='${JSON.stringify(textChords)}'>` + value + "</span>"
+                html += `<span data-freeshow-text="true" class="${a.customType && !a.customType.includes("jw") ? "custom" : ""}" ${plain ? `data-text-index="${tIndex}"` : textStyle} data-customtype='${a.customType || ""}' data-sourcedynamickey='${a.sourceDynamicKey || ""}' data-chords='${JSON.stringify(textChords)}'>` + value + "</span>"
             })
             html += "</div>"
         })

--- a/src/frontend/components/edit/editbox/EditboxHelper.ts
+++ b/src/frontend/components/edit/editbox/EditboxHelper.ts
@@ -83,12 +83,32 @@ export class EditboxHelper {
             // Update start position if this line has a selection start
             if (sel[i]?.start !== undefined) start = currentIndex + sel[i].start!
 
+            const lineStartIndex = currentIndex
             if (start > -1 && currentIndex >= start) secondLines.push({ align: line.align, text: [] })
             else firstLines.push({ align: line.align, text: [] })
+            const firstHalf = start > -1 && lineStartIndex >= start ? null : firstLines[firstLines.length - 1]
 
             textPos = 0
             if (!Array.isArray(line.text)) line.text = []
             line.text.forEach(splitLines)
+
+            // keep chords with their line, a mid-line split partitions them by the split offset
+            const lineChords = line.chords || []
+            if (lineChords.length) {
+                if (start > -1 && lineStartIndex >= start) {
+                    const target = secondLines[secondLines.length - 1]
+                    if (target) target.chords = lineChords
+                } else if (start > lineStartIndex && start < currentIndex) {
+                    const localSplit = start - lineStartIndex
+                    const firstChords = lineChords.filter((a) => a.pos < localSplit)
+                    const secondChords = lineChords.filter((a) => a.pos >= localSplit).map((a) => ({ ...a, pos: a.pos - localSplit }))
+                    if (firstHalf && firstChords.length) firstHalf.chords = firstChords
+                    const secondTarget = secondLines[secondLines.length - 1]
+                    if (secondTarget && secondChords.length) secondTarget.chords = secondChords
+                } else if (firstHalf) {
+                    firstHalf.chords = lineChords
+                }
+            }
 
             if (!firstLines.at(-1)?.text.length) firstLines.pop()
             if (!secondLines.at(0)?.text.length) secondLines.shift()
@@ -152,13 +172,6 @@ export class EditboxHelper {
         if (!firstLines.length || !firstLines[0].text.length) firstLines = defaultLine
         if (!secondLines.length) secondLines = defaultLine
 
-        // add chords (currently only adding full line chords, so splitting in the middle of a line might shift chords)
-        const chordLines = clone(lines.map((a) => a.chords || []))
-        ;[...firstLines, ...secondLines].forEach((line) => {
-            const oldLineChords = chordLines.shift()
-            if (oldLineChords?.length) line.chords = oldLineChords
-        })
-
         return { firstLines, secondLines }
     }
 
@@ -194,9 +207,10 @@ export class EditboxHelper {
             line.text.forEach((a, tIndex) => {
                 currentStyle += this.getTextStyle(a)
 
-                // SAVE CHORDS (WIP does not work well with more "text" per line)
+                // each chord is stored in exactly one segment, the last segment absorbs end-of-line positions
+                const isLastSegment = tIndex === line.text.length - 1
                 const textEnd = textIndex + a.value.length
-                const textChords = currentChords.filter((chord) => chord.pos >= textIndex && (chord.pos <= textEnd || line.text.length - 1 >= tIndex))
+                const textChords = currentChords.filter((chord) => chord.pos >= textIndex && (chord.pos < textEnd || isLastSegment))
                 textIndex = textEnd
 
                 const textStyle = a.style || listStyle ? 'style="' + this.getCustomTextStyle(a.style) + listStyle + '"' : ""

--- a/src/frontend/components/edit/editbox/EditboxHelper.ts
+++ b/src/frontend/components/edit/editbox/EditboxHelper.ts
@@ -170,7 +170,10 @@ export class EditboxHelper {
         const lineStyleRadius = item.specialStyle?.lineRadius ? `border-radius: ${item.specialStyle.lineRadius}px;` : ""
         const listStyle = "" // item.list?.enabled ? `;list-style${item.list?.style?.includes("disclosure") ? "-type:" : ": inside"} ${item.list?.style || "disc"};` : "" // item.list?.enabled ? ";display: list-item;" : ""
 
-        item?.lines?.forEach((line, i) => {
+        // a contenteditable without any line blocks can't receive line breaks, so always render at least one
+        const lines: Line[] = item?.lines?.length ? item.lines : [{ align: "", text: [{ style: "", value: "" }] }]
+
+        lines.forEach((line, i) => {
             const align = (typeof line.align === "string" ? line.align : "").replaceAll(lineStyleBg, "").replaceAll(lineStyleRadius, "") + ";"
             currentStyle += align + lineStyleBg + lineStyleRadius // + line.chords?.map((a) => a.key)
             const style = align || lineStyleBg || lineStyleRadius || listStyle ? 'style="' + align + lineStyleBg + lineStyleRadius + listStyle + '"' : ""

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -516,12 +516,14 @@
             if (lineChords?.length) {
                 newLines[pos].chords = lineChords
 
-                // UPDATE/FIX CHORDS ON LINE BREAK
-                if (pos > 0 && JSON.stringify(newLines[pos].chords) === JSON.stringify(newLines[pos - 1].chords)) {
+                // UPDATE/FIX CHORDS ON LINE BREAK (the browser clones the data-chords attributes when splitting a line)
+                const previousChordIds = newLines[pos - 1]?.chords?.map((a) => a.id) || []
+                const shared = (a) => previousChordIds.includes(a.id)
+                if (pos > 0 && newLines[pos].chords!.some(shared)) {
                     let breakPoint = newLines[pos - 1].text.reduce((textLength, text) => (textLength += text.value.length), 0)
 
-                    newLines[pos - 1].chords = newLines[pos - 1].chords!.filter((a) => a.pos < breakPoint)
-                    newLines[pos].chords = newLines[pos].chords!.filter((a) => a.pos >= breakPoint).map((a) => ({ ...a, pos: a.pos - breakPoint }))
+                    newLines[pos - 1].chords = newLines[pos - 1].chords!.filter((a) => !shared(a) || a.pos < breakPoint)
+                    newLines[pos].chords = newLines[pos].chords!.filter((a) => !shared(a) || a.pos >= breakPoint).map((a) => (shared(a) && a.pos >= breakPoint ? { ...a, pos: a.pos - breakPoint } : a))
                 }
             }
         })

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -38,9 +38,6 @@
     let previousHTML = ""
     let currentStyle = ""
 
-    // WIP pressing line break on empty html (textbox) does not work, but it works after typing something
-    // NOTE: undoing a change will set the html to "", causing the same issue
-
     onMount(() => {
         getStyle()
 

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -424,8 +424,15 @@
         currentStyle = ""
         let updateHTML = false
 
+        // plain mode DOM carries no styles, resolve the source line/text by identity attributes (survives line splits/merges)
+        const attrIndex = (elem: any, name: string, fallback: number) => {
+            const value = Number(elem.getAttribute?.(name) ?? NaN)
+            return isNaN(value) ? fallback : value
+        }
+
         new Array(...textElem.children).forEach((line: any, i) => {
-            let align: string = plain ? (typeof item.lines?.[i]?.align === "string" ? (item.lines?.[i]?.align as string) : "") : line.getAttribute("style") || ""
+            const sourceLine = plain ? attrIndex(line, "data-line-index", i) : i
+            let align: string = plain ? (typeof item.lines?.[sourceLine]?.align === "string" ? (item.lines?.[sourceLine]?.align as string) : "") : line.getAttribute("style") || ""
             align = align.replaceAll(lineStyleBg, "").replaceAll(lineStyleRadius, "") + ";"
             pos++
             currentStyle += align + lineStyleBg + lineStyleRadius
@@ -440,7 +447,7 @@
                     // add "floating" text to previous node (e.g. pressing backspace at the start of a line)
                     // preserve style when merging lines with different styling (macOS issue)
                     let lastNode = newLines[pos].text.length - 1
-                    let originalLineStyle = item.lines?.[i]?.text?.[0]?.style || ""
+                    let originalLineStyle = item.lines?.[sourceLine]?.text?.[0]?.style || ""
                     let lastNodeStyle = lastNode >= 0 ? newLines[pos].text[lastNode]?.style || "" : ""
 
                     // Create new segment if no previous node or styles differ
@@ -458,16 +465,15 @@
                     const strayText = child.nodeType === Node.ELEMENT_NODE ? (child.innerText || "").replaceAll("\n", "") : ""
                     if (strayText) {
                         let lastNode = newLines[pos].text.length - 1
-                        if (lastNode < 0) newLines[pos].text.push({ style: item.lines?.[i]?.text?.[0]?.style || "", value: strayText })
+                        if (lastNode < 0) newLines[pos].text.push({ style: item.lines?.[sourceLine]?.text?.[0]?.style || "", value: strayText })
                         else newLines[pos].text[lastNode].value += strayText
                         updateHTML = true
                     }
                     return
                 }
 
-                let style = plain ? item.lines?.[i]?.text[j]?.style || "" : child.getAttribute("style") || ""
-                // TODO: pressing enter / backspace will remove any following style in list view
-                // if (plain && !style && i > 0) style = item.lines![i - 1]?.text[j]?.style
+                const sourceText = plain ? attrIndex(child, "data-text-index", j) : j
+                let style = plain ? item.lines?.[sourceLine]?.text[sourceText]?.style || "" : child.getAttribute("style") || ""
 
                 let lineText = child.innerText
                 // empty line

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -38,6 +38,8 @@
     let previousHTML = ""
     let currentStyle = ""
 
+    // WIP pressing line break on empty html (textbox) does not work, but it works after typing something
+
     onMount(() => {
         getStyle()
 

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -456,7 +456,17 @@
                     updateHTML = true
                     return
                 }
-                if (child.nodeName !== "SPAN") return
+                if (child.nodeName !== "SPAN") {
+                    // merge stray elements the browser sometimes creates on backspace/delete (e.g. <font>) into the previous segment
+                    const strayText = child.nodeType === Node.ELEMENT_NODE ? (child.innerText || "").replaceAll("\n", "") : ""
+                    if (strayText) {
+                        let lastNode = newLines[pos].text.length - 1
+                        if (lastNode < 0) newLines[pos].text.push({ style: item.lines?.[i]?.text?.[0]?.style || "", value: strayText })
+                        else newLines[pos].text[lastNode].value += strayText
+                        updateHTML = true
+                    }
+                    return
+                }
 
                 let style = plain ? item.lines?.[i]?.text[j]?.style || "" : child.getAttribute("style") || ""
                 // TODO: pressing enter / backspace will remove any following style in list view
@@ -564,8 +574,10 @@
             }
         }
 
-        // For keyboard line operations, prefer the live caret from the contenteditable DOM.
-        if (keyboardLineMutation && liveCaret) caret = liveCaret
+        // For keyboard line operations that changed the line structure, prefer the live caret from the contenteditable DOM.
+        // In-line edits (e.g. backspace inside a line) must not rebuild the HTML, that would destroy the browser's own caret.
+        const structureChanged = (item.lines || []).length !== newLines.length || newLines.some((line, i) => (line.text?.length || 0) !== (item.lines?.[i]?.text?.length || 0))
+        if (keyboardLineMutation && liveCaret && structureChanged) caret = liveCaret
 
         if (caret) {
             item.lines = newLines

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -136,23 +136,22 @@
 
         // WIP replace with exising altKeys cut_in_half shortcuts.ts
 
-        // TODO: get working in list view
         if (e.key === "Enter" && (e.target?.closest(".item") || e.target?.closest(".quickEdit"))) {
-            // incorrect editbox
+            // only the focused editbox instance should handle the split
+            if (e.target !== textElem) return
             if (e.target.closest(".quickEdit") && Number(e.target.closest(".quickEdit").getAttribute("data-index")) !== editIndex) return
             if (!e.target.closest(".quickEdit") && !$activeEdit.items.includes(index)) return
+
+            if (!e.altKey) return
 
             // split
             let sel = getSelectionRange()
             if (!sel?.length || (sel.length === 1 && !Object.keys(sel[0]).length)) return
 
-            // if (sel.start === sel.end) {
             let lines: Line[] = getNewLines()
             let currentIndex = 0,
                 textPos = 0
             let start = -1
-
-            if (!e.altKey) return
 
             cutInTwo({ e, sel, lines: clone(lines), currentIndex, textPos, start })
         }
@@ -164,8 +163,10 @@
         if ((ref.type || "show") !== "show") return
         let { firstLines, secondLines } = EditboxHelper.cutLinesInTwo({ sel, lines, currentIndex, textPos, start })
 
-        if (typeof $activeEdit.slide === "number") editIndex = $activeEdit.slide
-        let editItemIndex: number = $activeEdit.items[0] ?? Number(e?.target?.closest(".editItem")?.getAttribute("data-index")) ?? 0
+        // in list view the component's own indexes are correct, $activeEdit might hold a stale edit tab state
+        if (!plain && typeof $activeEdit.slide === "number") editIndex = $activeEdit.slide
+        let domItemIndex = Number(e?.target?.closest(".editItem")?.getAttribute("data-index"))
+        let editItemIndex: number = plain ? index : ($activeEdit.items[0] ?? (isNaN(domItemIndex) ? 0 : domItemIndex))
 
         let layoutRef = getLayoutRef()
         let slideRef = layoutRef[editIndex]

--- a/src/frontend/components/edit/editors/SlideEditor.svelte
+++ b/src/frontend/components/edit/editors/SlideEditor.svelte
@@ -13,7 +13,7 @@
     import { history } from "../../helpers/history"
     import { getExtension, getMedia, getMediaFileFromClipboard, getMediaLayerType, getMediaStyle, getMediaType, getThumbnailPath, mediaSize } from "../../helpers/media"
     import { getFirstActiveOutput, getResolution, getSlideFilter } from "../../helpers/output"
-    import { getLayoutRef } from "../../helpers/show"
+    import { getLayoutRef, isSlideLocked } from "../../helpers/show"
     import { _show } from "../../helpers/shows"
     import { getStyles } from "../../helpers/style"
     import FloatingInputs from "../../input/FloatingInputs.svelte"
@@ -261,7 +261,7 @@
     )
 
     let profile = getAccess("shows")
-    $: isGroupLocked = !!Slide?.locked // WIP get group slide
+    $: isGroupLocked = isSlideLocked(currentShowId, ref[$activeEdit.slide ?? -1]?.id || "", $showsCache)
     $: isLocked = currentShow?.locked || isGroupLocked || profile.global === "read" || profile[currentShow?.category || ""] === "read"
 
     // remove overflow if scrollbars are flickering over 25 times per second

--- a/src/frontend/components/edit/editors/SlideEditor.svelte
+++ b/src/frontend/components/edit/editors/SlideEditor.svelte
@@ -298,14 +298,14 @@
 
     // BACKGROUND
 
-    $: currentBackgroundPath = currentShow?.media?.[ref[$activeEdit.slide || 0]?.data.background || ""]?.path || ""
+    $: currentBackgroundPath = currentShow?.media?.[ref[$activeEdit.slide ?? -1]?.data.background || ""]?.path || ""
     $: hasBackground = !!currentBackgroundPath
     function convertBackgroundToMedia() {
         // add behind all other items
         addItem("media", null, { src: currentBackgroundPath }, "", { left: "0px", top: "0px", width: "1920px", height: "1080px" }, 0)
 
         showsCache.update((a) => {
-            const currentRef = ref[$activeEdit.slide || 0]
+            const currentRef = ref[$activeEdit.slide ?? -1]
             if (!currentRef) return a
 
             const layoutId = currentShow?.settings?.activeLayout || ""

--- a/src/frontend/components/edit/scripts/autosize.ts
+++ b/src/frontend/components/edit/scripts/autosize.ts
@@ -135,9 +135,10 @@ export default function autosize(elem: HTMLElement, { type, textQuery, defaultFo
         cloned.style.height = `${newHeight}px`
         cloned.style.padding = "0"
 
-        // "align-items: flex-end;" does not work with auto size
-        cloned.style.alignItems = "center"
-        if (cloned.querySelector(".edit")) (cloned.querySelector(".edit") as HTMLElement).style.justifyContent = "center"
+        // scrollHeight only measures overflow below the box: with flex-end (and half of it with center) overflow is invisible to it,
+        // so measure with flex-start - vertical alignment does not affect the content size, the computed fit is the same
+        cloned.style.alignItems = "flex-start"
+        if (cloned.querySelector(".edit")) (cloned.querySelector(".edit") as HTMLElement).style.justifyContent = "flex-start"
 
         for (const elemHide of Array.from(cloned.querySelectorAll(".hideFromAutosize"))) {
             ;(elemHide as HTMLElement).style.display = "none"

--- a/src/frontend/components/edit/scripts/itemClipboard.ts
+++ b/src/frontend/components/edit/scripts/itemClipboard.ts
@@ -226,8 +226,6 @@ export async function setBoxStyle(styles: StyleClipboard[], slides: any, type: I
 }
 
 export async function setItemStyle(styles: StyleClipboard[], slides: any) {
-    // TODO: pasting to multiple items will move around the text lines content
-
     const itemKeys = getItemKeys()
 
     for (const slide of slides) {
@@ -240,10 +238,8 @@ export async function setItemStyle(styles: StyleClipboard[], slides: any) {
     function updateSlideStyle(slide) {
         const values: string[] = []
 
-        let items: number[] = []
+        const items: number[] = []
         slide.items.forEach(updateItemStyle)
-        // fix items swapping positions!
-        items = items.reverse()
 
         history({
             id: "setStyle",

--- a/src/frontend/components/edit/scripts/itemClipboard.ts
+++ b/src/frontend/components/edit/scripts/itemClipboard.ts
@@ -226,6 +226,8 @@ export async function setBoxStyle(styles: StyleClipboard[], slides: any, type: I
 }
 
 export async function setItemStyle(styles: StyleClipboard[], slides: any) {
+    // TODO: pasting to multiple items will move around the text lines content
+
     const itemKeys = getItemKeys()
 
     for (const slide of slides) {
@@ -238,8 +240,10 @@ export async function setItemStyle(styles: StyleClipboard[], slides: any) {
     function updateSlideStyle(slide) {
         const values: string[] = []
 
-        const items: number[] = []
+        let items: number[] = []
         slide.items.forEach(updateItemStyle)
+        // fix items swapping positions!
+        items = items.reverse()
 
         history({
             id: "setStyle",

--- a/src/frontend/components/edit/scripts/itemClipboard.ts
+++ b/src/frontend/components/edit/scripts/itemClipboard.ts
@@ -4,7 +4,7 @@ import { activeEdit, activeShow, showsCache } from "../../../stores"
 import { wait } from "../../../utils/common"
 import { clone } from "../../helpers/array"
 import { history } from "../../helpers/history"
-import { getLayoutRef } from "../../helpers/show"
+import { getLayoutRef, isSlideLocked } from "../../helpers/show"
 import { _show } from "../../helpers/shows"
 import { getStyles } from "../../helpers/style"
 import { itemBoxes } from "../values/boxes"
@@ -278,7 +278,7 @@ export async function setItemStyle(styles: StyleClipboard[], slides: any) {
 
 export async function setSlideStyle(style: StyleClipboard, slides: any) {
     for (const slide of slides) {
-        if (slide.locked) continue // WIP get group slide
+        if (isSlideLocked(get(activeShow)?.id || "", slide.id)) continue
 
         updateSlideStyle(slide)
 

--- a/src/frontend/components/edit/scripts/itemHelpers.ts
+++ b/src/frontend/components/edit/scripts/itemHelpers.ts
@@ -331,7 +331,6 @@ function getTempItems(item: Item, allItems: Item[]) {
     const currentSlide = currentOutput.out?.slide || (slideOffset !== 0 ? get(outputSlideCache)[stageOutputId] || null : null)
 
     if (currentSlide?.id !== "temp") return allItems
-    // slide offsets outside the generated previous/next slides resolve to undefined
     return getTempSlides() || []
 
     function getTempSlides() {

--- a/src/frontend/components/edit/scripts/itemHelpers.ts
+++ b/src/frontend/components/edit/scripts/itemHelpers.ts
@@ -324,7 +324,6 @@ export function shouldItemBeShown(item: Item, allItems: Item[] = [], { outputId,
 }
 
 // get "temp" items (scripture) if stage
-// TODO: fix "Maximum call stack size exceeded"
 function getTempItems(item: Item, allItems: Item[]) {
     const stageOutputId = getStageOutputId(get(outputs))
     const currentOutput = get(outputs)[stageOutputId] || get(allOutputs)[stageOutputId] || {}
@@ -332,7 +331,8 @@ function getTempItems(item: Item, allItems: Item[]) {
     const currentSlide = currentOutput.out?.slide || (slideOffset !== 0 ? get(outputSlideCache)[stageOutputId] || null : null)
 
     if (currentSlide?.id !== "temp") return allItems
-    return getTempSlides()
+    // slide offsets outside the generated previous/next slides resolve to undefined
+    return getTempSlides() || []
 
     function getTempSlides() {
         if (slideOffset < 0) {

--- a/src/frontend/components/edit/scripts/textStyle.ts
+++ b/src/frontend/components/edit/scripts/textStyle.ts
@@ -20,7 +20,8 @@ export function addStyle(selection: { start: number; end: number }[], item: Item
 
                 if ((pos < selection[i].start && pos + length > selection[i].start) || (pos < selection[i].end && pos + length > selection[i].end) || (pos >= selection[i].start && pos + length <= selection[i].end)) {
                     if (from > 0) newText.push({ value: value.slice(0, from), style: text.style })
-                    if (to - from > 0 && to - from <= length) {
+                    // also style covered empty text (e.g. an empty textbox), otherwise it would keep the old style
+                    if ((to - from > 0 || length === 0) && to - from <= length) {
                         let newStyle = ""
                         if (Array.isArray(style)) newStyle = addStyleString(text.style, style)
                         else newStyle = style

--- a/src/frontend/components/edit/scripts/textStyle.ts
+++ b/src/frontend/components/edit/scripts/textStyle.ts
@@ -350,29 +350,33 @@ export function getLineText(line: Line): string {
 }
 
 export function setCaret(element: any, { line = 0, pos = 0 }, toEnd = false) {
-    if (!element) return
+    if (!element?.childNodes?.length) return
     const range = document.createRange()
     const sel = window.getSelection()
 
-    const lineElem = element.childNodes[line]
+    const lineElem = element.childNodes[Math.min(line, element.childNodes.length - 1)]
     if (!lineElem) return
+
+    // count like getSelectionRange: include plain text nodes, don't count line breaks
+    const nodeTextLength = (node: any) => (((node?.innerText ?? node?.textContent) || "") as string).replaceAll("\n", "").length
 
     // get child elem
     let childElem = -1
     let currentTextLength = 0
     lineElem.childNodes.forEach((elem, i) => {
-        if (!elem?.innerText || childElem >= 0) return
-        if (pos <= currentTextLength + elem.innerText.length) {
+        if (childElem >= 0) return
+        const textLength = nodeTextLength(elem)
+        if (pos <= currentTextLength + textLength) {
             childElem = i
             return
         }
-        currentTextLength += elem.innerText.length
+        currentTextLength += textLength
     })
 
     // pasted on non-existent line
     if (childElem < 0) {
         childElem = lineElem.childNodes.length - 1
-        pos = lineElem.childNodes[childElem]?.innerText?.length ?? 0
+        pos = nodeTextLength(lineElem.childNodes[childElem])
         currentTextLength = 0
     }
 
@@ -386,34 +390,32 @@ export function setCaret(element: any, { line = 0, pos = 0 }, toEnd = false) {
 
     // get end child elem
     const lastEndChild = lastLineElem.childNodes[lastLineElem.childNodes.length - 1]
-    if (!lastEndChild) return
-    let currentEndTextLength = lastEndChild.innerText?.length ?? 0
+    let currentEndTextLength = lastEndChild ? nodeTextLength(lastEndChild) : 0
 
-    const breakElem = lastEndChild.childNodes[0]?.nodeName === "BR"
-    if (line === 0 && breakElem) return
+    const startChild = lineElem.childNodes[childElem]
+    const startElem = startChild?.nodeType === Node.TEXT_NODE ? startChild : startChild?.childNodes[0]
+    const endElem = lastEndChild?.nodeType === Node.TEXT_NODE ? lastEndChild : lastEndChild?.childNodes[0]
 
-    const startElem = lineElem.childNodes[childElem]?.childNodes[0]
-    const endElem = lastEndChild.childNodes[0]
-
-    // If startElem is a BR element, set caret before it and not inside it
-    if (startElem?.nodeName === "BR") {
-        const parentSpan = lineElem.childNodes[childElem]
-        try {
-            range.setStart(parentSpan, 0)
-        } catch {
-            return
+    // always position the range, a fresh unpositioned range would collapse the caret to the start
+    try {
+        if (startElem?.nodeName === "BR") {
+            // if startElem is a BR element, set caret before it and not inside it
+            range.setStart(startElem.parentNode || lineElem, 0)
+        } else if (startElem?.nodeType === Node.TEXT_NODE) {
+            const offset = pos - currentTextLength
+            const startElemLength = startElem.length ?? startElem.textContent?.length ?? 0
+            range.setStart(startElem, Math.max(0, Math.min(startElemLength, offset)))
+        } else if (startChild) {
+            range.setStart(lineElem, Math.max(0, Math.min(lineElem.childNodes.length, childElem)))
+        } else {
+            range.setStart(lineElem, 0)
         }
-    } else if (startElem) {
-        const offset = pos - currentTextLength
-        const startElemLength = startElem.length ?? startElem.textContent?.length ?? 0
-        const safeStartOffset = Math.max(0, Math.min(startElemLength, offset))
-        try {
-            range.setStart(startElem, safeStartOffset)
-        } catch {
-            return
-        }
+    } catch {
+        range.selectNodeContents(lineElem)
+        range.collapse(false)
     }
-    if (toEnd) {
+
+    if (toEnd && lastEndChild) {
         let safeEndOffset = 0
         if (endElem?.nodeType === Node.TEXT_NODE) {
             safeEndOffset = Math.max(0, Math.min(endElem.length ?? endElem.textContent?.length ?? 0, currentEndTextLength))
@@ -421,11 +423,11 @@ export function setCaret(element: any, { line = 0, pos = 0 }, toEnd = false) {
             safeEndOffset = Math.max(0, Math.min(endElem.childNodes.length, currentEndTextLength))
         }
         try {
-            range.setEnd(endElem, safeEndOffset)
+            range.setEnd(endElem || lastEndChild, safeEndOffset)
         } catch {
-            return
+            range.collapse(true)
         }
-    } else range.collapse(true)
+    } else if (!toEnd) range.collapse(true)
 
     sel?.removeAllRanges()
     sel?.addRange(range)

--- a/src/frontend/components/edit/tools/BoxStyle.svelte
+++ b/src/frontend/components/edit/tools/BoxStyle.svelte
@@ -230,7 +230,7 @@
 
     const setBox = () => clone(itemBoxes[id])!
     let box = setBox()
-    $: if ($activeEdit.id || $activeShow?.id || $activeEdit.slide) box = setBox()
+    $: if ($activeEdit.id || $activeShow?.id || ($activeEdit.slide ?? -1) > -1) box = setBox()
 
     // get item values
     $: style = item?.lines ? getItemStyleAtPos(item.lines, selection) : item?.type === "table" && activeRowIdx >= 0 && activeColIdx >= 0 && item.table?.rows?.[activeRowIdx]?.cells?.[activeColIdx] ? item.table.rows[activeRowIdx].cells[activeColIdx].style || "" : item?.style || ""
@@ -269,8 +269,6 @@
         setBoxInputValue(box, "lines", "specialStyle.lineRadius", "hidden", !item?.specialStyle?.lineRadius && !item?.specialStyle?.lineBg)
 
         setBoxInputValue(box, "default", "textFit", "value", item?.auto ? "shrinkToFit" : "none") // text items
-        // WIP disabled auto size -- don't disable if all text is selected
-        // setBoxInputValue(box, "default", "font-size", "disabled", selection?.length)
     }
 
     $: if (id === "media" && item) {
@@ -429,6 +427,36 @@
         }
     }
 
+    function isPartialTextSelection() {
+        if (!selection?.length || !selection.some((a) => a?.start !== undefined && a.start !== a.end)) return false
+        if (!item?.lines?.length) return false
+        return !item.lines.every((line, i) => selection![i]?.start === 0 && selection![i]?.end === getLineText(line).length)
+    }
+
+    function disableAutoSize(items: number[]) {
+        if ($activeEdit.id) {
+            if ($activeEdit.type === "overlay") overlays.update(updateAutoSize)
+            else if ($activeEdit.type === "template") templates.update(updateAutoSize)
+            return
+        }
+
+        const location = { page: "edit" as const, show: $activeShow!, slide: getLayoutRef()[$activeEdit.slide!]?.id, items }
+        // separate location ids so the different keys don't get coalesced into one history entry
+        history({ id: "setItems", newData: { style: { key: "textFit", values: ["none"] } }, location: { ...location, id: "textFit" } })
+        history({ id: "setItems", newData: { style: { key: "auto", values: [false] } }, location: { ...location, id: "auto" } })
+
+        function updateAutoSize(a: any) {
+            if (!a[$activeEdit.id!]?.items) return a
+            items.forEach((i) => {
+                if (!a[$activeEdit.id!].items[i]) return
+                a[$activeEdit.id!].items[i].textFit = "none"
+                a[$activeEdit.id!].items[i].auto = false
+            })
+            a[$activeEdit.id!].modified = Date.now()
+            return a
+        }
+    }
+
     function updateValue(e: any) {
         let input = e.detail
         console.log("BOX INPUT:", input)
@@ -441,7 +469,7 @@
         const colIdx = td ? parseInt(td.getAttribute("data-col") || "") : -1
 
         if (item?.type === "table" && rowIdx >= 0 && colIdx >= 0 && input.key && item.table?.rows?.[rowIdx]?.cells?.[colIdx]) {
-            let allItems: number[] = $activeEdit.items
+            let allItems: number[] = [...$activeEdit.items]
             if (!allItems.length) allSlideItems.forEach((_item, i) => allItems.push(i))
             let cellStyle = item.table.rows[rowIdx].cells[colIdx].style || ""
             cellStyle = addStyleString(cellStyle, [input.key, input.value])
@@ -450,13 +478,7 @@
             return
         }
 
-        // does not work for partial text when auto size is enabled
-        // WIP doesn't need to show if disabled works correctly
-        if (id === "text" && input.key === "font-size" && selection?.length && (item?.textFit || "none") !== "none") {
-            newToast("edit.auto_size settings.enabled!")
-        }
-
-        let allItems: number[] = $activeEdit.items
+        let allItems: number[] = [...$activeEdit.items]
         // update all items if nothing is selected
         if (!allItems.length) allSlideItems.forEach((_item, i) => allItems.push(i))
         allSlideItems = clone(allSlideItems)
@@ -465,8 +487,14 @@
         if (($activeEdit.type || "show") === "show") allItems = allItems.reverse()
 
         // only same type
-        let currentType = id || allSlideItems[allItems[0]].type || "text"
-        allItems = allItems.filter((index) => (allSlideItems[index].type || "text") === currentType)
+        let currentType = id || allSlideItems[allItems[0]]?.type || "text"
+        allItems = allItems.filter((index) => (allSlideItems[index]?.type || "text") === currentType)
+
+        // font size on a partial selection is invisible while auto size is enabled, so disable auto size first
+        if (id === "text" && input.id === "style" && input.key === "font-size" && input.name !== "font_size" && (item?.auto || (item?.textFit || "none") !== "none") && isPartialTextSelection()) {
+            disableAutoSize(allItems)
+            newToast("toast.autosize_disabled")
+        }
 
         if (input.id === "nowrap") input = { ...input, id: "style", key: "white-space", value: input.value ? "nowrap" : undefined }
 
@@ -546,10 +574,10 @@
                 }
             } else {
                 if (input.id.includes("CSS")) {
-                    values[slideId] = [input.value]
+                    values[slideId].push(input.value)
                 } else {
-                    // TODO: don't replace full item style (position) when changing multiple (Like EditTools.svelte:152)
-                    values[slideId] = [addStyleString(item?.style || "", [input.key, input.value])]
+                    // merge into each item's own style so position etc. is kept when changing multiple items
+                    values[slideId].push(addStyleString(currentSlideItem.style || "", [input.key, input.value]))
                 }
             }
         }
@@ -569,39 +597,33 @@
         // update layout
         if ($activeEdit.id) {
             // overlay / template
-            let currentItems: Item[] = []
-            if ($activeEdit.type === "overlay") currentItems = clone($overlays[$activeEdit.id]?.items || [])
-            if ($activeEdit.type === "template") currentItems = clone($templates[$activeEdit.id]?.items || [])
-            // only selected
-            currentItems = currentItems.filter((_item, i) => allItems.includes(i))
-
-            // WIP changing the default "Name" overlay causes textbox swapping....
+            const sourceItems = ($activeEdit.type === "overlay" ? $overlays[$activeEdit.id]?.items : $templates[$activeEdit.id]?.items) || []
+            // pair each selected item with its own computed value (data & indexes must stay aligned)
+            let currentItems: Item[] = allItems.map((itemIndex) => clone(sourceItems[itemIndex]))
+            const allValues: any[] = Object.values(values)[0] || []
 
             allItems.forEach((_itemIndex, i) => {
                 if (!currentItems[i]) return
 
-                let allValues: any = Object.values(values)[0] || []
                 let currentValue: any = allValues[i] ?? allValues[0]
-                // some textboxes don't have lines, this will break things, so make sure it has lines!
-                if (currentItems[i].lines && typeof currentValue === "string") currentValue = allValues.find((a: any) => typeof a !== "string") || allValues[0]
+                if (currentValue === undefined) return
 
                 if (input.key === "align-items") currentItems[i].align = currentValue
-                else if (currentType !== "text") currentItems[i].style = currentValue
+                else if (currentType !== "text" || (!currentItems[i].lines && typeof currentValue === "string")) currentItems[i].style = currentValue
                 else {
                     let lines = currentItems[i].lines
                     lines?.forEach((_a, j) => {
-                        if (currentItems[i].lines?.[j] && currentValue) {
+                        if (currentItems[i].lines?.[j] && currentValue?.[j] !== undefined) {
                             currentItems[i].lines![j][aligns ? "align" : "text"] = currentValue[j]
                         }
                     })
                 }
             })
 
-            // WIP if top textbox is empty, and another has text, that will update (but the right side won't update (as top is empty as not changed)), that is confusing
-
             // no text
-            if (currentItems[0]?.lines) {
-                let textLength = currentItems.reduce((length, item) => (length += getItemText(item).length), 0)
+            const textItems = currentItems.filter((a) => a?.lines)
+            if (textItems.length) {
+                let textLength = textItems.reduce((length, item) => (length += getItemText(item).length), 0)
                 if (!textLength) {
                     newToast("empty.text")
                     return

--- a/src/frontend/components/edit/tools/BoxStyle.svelte
+++ b/src/frontend/components/edit/tools/BoxStyle.svelte
@@ -656,14 +656,6 @@
             return
         }
 
-        // no text
-        // values: {key: [[[]]]}
-        let textLength = Object.values(values).reduce((length: number, value: any) => length + value.flat(2).reduce((value, text) => value + (text?.value || ""), "").length, 0)
-        if (input.key !== "text-align" && !aligns && !textLength) {
-            newToast("empty.text")
-            return
-        }
-
         let key: string = input.key === "text-align" || aligns ? "align" : "text"
         slides.forEach((slide, i) => {
             if (!slideItems[i].length) return

--- a/src/frontend/components/edit/tools/ItemStyle.svelte
+++ b/src/frontend/components/edit/tools/ItemStyle.svelte
@@ -76,7 +76,7 @@
             }
         }
 
-        let allItems: number[] = [...$activeEdit.items]
+        let allItems: number[] = clone($activeEdit.items)
 
         // update all items if nothing is selected
         if (!allItems.length) allSlideItems.forEach((_item, i) => allItems.push(i))

--- a/src/frontend/components/edit/tools/ItemStyle.svelte
+++ b/src/frontend/components/edit/tools/ItemStyle.svelte
@@ -76,7 +76,7 @@
             }
         }
 
-        let allItems: number[] = $activeEdit.items
+        let allItems: number[] = [...$activeEdit.items]
 
         // update all items if nothing is selected
         if (!allItems.length) allSlideItems.forEach((_item, i) => allItems.push(i))

--- a/src/frontend/components/helpers/clipboard.ts
+++ b/src/frontend/components/helpers/clipboard.ts
@@ -68,6 +68,7 @@ import { activeEdit } from "./../../stores"
 import { clone, keysToID, removeDeleted, removeDuplicates } from "./array"
 import { pasteText } from "./caretHelper"
 import { history } from "./history"
+import { deleteStore } from "./historyStores"
 import { getFileName, removeExtension } from "./media"
 import { select } from "./select"
 import { loadShows } from "./setShow"
@@ -734,15 +735,8 @@ const deleteActions = {
         history({ id: "SLIDES", oldData: { type: "delete_group", data: data.map(({ id }: any) => ({ id })) } })
     },
     action: (data: any) => {
-        // WIP history
-        data.forEach((selData) => {
-            actions.update((a) => {
-                delete a[selData.id]
-                return a
-            })
-
-            sendMain(Main.CLOSE_MIDI, { id: selData.id })
-        })
+        historyDelete("UPDATE", data, { updater: "action" })
+        data.forEach((selData) => sendMain(Main.CLOSE_MIDI, { id: selData.id }))
     },
     timer: (data: any) => {
         data.forEach((a) => {
@@ -751,24 +745,11 @@ const deleteActions = {
         })
     },
     global_timer: (data: any) => deleteActions.timer(data),
-    // TODO: history
     variable: (data: any) => {
-        variables.update((a) => {
-            data.forEach(({ id }) => {
-                delete a[id]
-            })
-
-            return a
-        })
+        data.forEach(({ id }) => deleteStore("variables", id))
     },
     interaction: (data: any) => {
-        // WIP history
-        interactions.update((a) => {
-            data.forEach(({ id }) => {
-                delete a[id]
-            })
-            return a
-        })
+        historyDelete("UPDATE", data, { updater: "interaction" })
     },
     interaction_input: (data: any) => {
         const id = get(openedInteractionId)
@@ -1149,7 +1130,8 @@ const duplicateActions = {
     },
     folder: (data: any) => {
         // duplicate projects folder and all of the projects inside
-        // TODO: history
+        // intentionally no undo: the recursive tree duplication has no batch history entry,
+        // and per-item entries could partially undo into orphaned children (deleting the copy has undo)
         const newProjects: Project[] = []
 
         folders.update((a) => {
@@ -1191,14 +1173,12 @@ const duplicateActions = {
         })
     },
     project: (data: any) => {
-        // TODO: history
-        projects.update((a) => {
-            data.forEach((project) => {
-                const newProject = clone(a[project.id])
-                a[uid()] = { ...newProject, name: newProject.name + " 2" }
-                return a
-            })
-            return a
+        data.forEach((selData) => {
+            const project = clone(get(projects)[selData.id])
+            if (!project) return
+
+            const id = uid()
+            history({ id: "UPDATE", newData: { data: project, replace: { name: project.name + " 2" } }, oldData: { id }, location: { page: "show", id: "project" } })
         })
     },
     theme: (data: any) => {

--- a/src/frontend/components/helpers/history.ts
+++ b/src/frontend/components/helpers/history.ts
@@ -2,7 +2,7 @@ import { get } from "svelte/store"
 import type { History, HistoryNew, HistoryTypes } from "../../../types/History"
 import { activePage, historyCacheCount, isDev, undoHistory } from "../../stores"
 import { redoHistory } from "./../../stores"
-import { clone } from "./array"
+import { areObjectsEqual, clone } from "./array"
 import { historyActions } from "./historyActions"
 import { createStore, createStoreHistory, deleteStore, deleteStoreHistory, updateStore, updateStoreHistory } from "./historyStores"
 import { deselect } from "./select"
@@ -21,6 +21,19 @@ export function historyAwait(s: string[], obj: History) {
         .catch((e) => {
             console.error(e)
         })
+}
+
+function isNoDataChange(obj: History) {
+    if (obj.id === "UPDATE") {
+        const data = obj.newData || {}
+        // deleting/creating entries only carry one of the values
+        if (data.previousData === undefined || data.data === undefined) return false
+        if (typeof data.previousData !== "object" || data.previousData === null || typeof data.data !== "object" || data.data === null) return data.previousData === data.data
+        return areObjectsEqual(data.previousData, data.data)
+    }
+
+    if (!obj.oldData || !obj.newData || typeof obj.oldData !== "object" || typeof obj.newData !== "object") return false
+    return areObjectsEqual(obj.oldData, obj.newData)
 }
 
 export function history(obj: History, shouldUndo: null | boolean = null) {
@@ -176,9 +189,9 @@ export function history(obj: History, shouldUndo: null | boolean = null) {
     if (old && !shouldUndo && !obj.oldData) obj.oldData = old
 
     if (obj.save === false) return
+    // don't create a history entry (or clear the redo stack) if nothing changed
+    if (shouldUndo === null && isNoDataChange(obj)) return
     if (shouldUndo === null) redoHistory.set([])
-
-    // TODO: remove history obj if oldData is exactly the same as newdata
 
     // if (obj.id !== "SAVE") {
     // TODO: go to location
@@ -191,7 +204,6 @@ export function history(obj: History, shouldUndo: null | boolean = null) {
         } else activePage.set(obj.location!.page)
     }
 
-    // TODO: slide text edit, dont override different style keys!
     // }
 
     if (shouldUndo) {
@@ -205,14 +217,17 @@ export function history(obj: History, shouldUndo: null | boolean = null) {
         })
     } else {
         undoHistory.update((uh: any) => {
+            const lastEntry = uh[uh.length - 1]
+            // only coalesce entries changing the same key, otherwise the other key's change would be lost on undo
+            const sameKeys = lastEntry?.newData?.style?.key === obj.newData?.style?.key && lastEntry?.newData?.key === obj.newData?.key && lastEntry?.newData?.subkey === obj.newData?.subkey
             // if id and location is equal push new data to previous stored
             // not: project | newProject | newFolder | addShowToProject | slide
-            if (shouldUndo === null && (override.includes(obj.id) || obj.location?.override) && uh[uh.length - 1]?.id === obj.id && JSON.stringify(Object.values(uh[uh.length - 1]?.location || {})) === JSON.stringify(Object.values(obj.location || {}))) {
+            if (shouldUndo === null && sameKeys && (override.includes(obj.id) || obj.location?.override) && lastEntry?.id === obj.id && JSON.stringify(Object.values(lastEntry?.location || {})) === JSON.stringify(Object.values(obj.location || {}))) {
                 // override, but keep previousData!!!
                 const newestData = obj.newData
-                if (newestData?.previousData) newestData.previousData = uh[uh.length - 1].newData.previousData
-                uh[uh.length - 1].newData = newestData
-                uh[uh.length - 1].time = Date.now()
+                if (newestData?.previousData) newestData.previousData = lastEntry.newData.previousData
+                lastEntry.newData = newestData
+                lastEntry.time = Date.now()
             } else {
                 // add to start if redo
                 // if (undo === false) uh = [obj, ...uh]

--- a/src/frontend/components/helpers/historyHelpers.ts
+++ b/src/frontend/components/helpers/historyHelpers.ts
@@ -2,7 +2,7 @@ import { get } from "svelte/store"
 import { uid } from "uid"
 import { REMOTE } from "../../../types/Channels"
 import { ShowObj } from "../../classes/Show"
-import { actions, activeDrawerTab, activeEdit, activeProject, activeRename, activeShow, activeStage, activeTagFilter, audioPlaylists, currentOutputSettings, dictionary, drawerTabsData, editingProjectTemplate, effects, events, focusMode, folders, globalTags, groups, notFound, openedFolders, overlays, playerVideos, profiles, projects, projectTemplates, projectView, shows, showsCache, special, stageShows, styles, theme, themes } from "../../stores"
+import { actions, activeDrawerTab, activeEdit, activeProject, activeRename, activeShow, activeStage, activeTagFilter, audioPlaylists, currentOutputSettings, dictionary, drawerTabsData, editingProjectTemplate, effects, events, focusMode, folders, globalTags, groups, interactions, notFound, openedFolders, overlays, playerVideos, profiles, projects, projectTemplates, projectView, shows, showsCache, special, stageShows, styles, theme, themes } from "../../stores"
 import { translateText } from "../../utils/language"
 import { updateThemeValues } from "../../utils/updateSettings"
 import { EMPTY_CATEGORY, EMPTY_EFFECT, EMPTY_EVENT, EMPTY_LAYOUT, EMPTY_PLAYER_VIDEO, EMPTY_PROJECT, EMPTY_PROJECT_FOLDER, EMPTY_SECTION, EMPTY_SLIDE, EMPTY_STAGE, EMPTY_TAG } from "../../values/empty"
@@ -589,6 +589,10 @@ export const _updaters = {
     action: {
         store: actions,
         empty: { name: "", triggers: [] }
+    },
+    interaction: {
+        store: interactions,
+        empty: { name: "", inputs: [] }
     }
 }
 

--- a/src/frontend/components/helpers/historyStores.ts
+++ b/src/frontend/components/helpers/historyStores.ts
@@ -27,7 +27,7 @@ export function updateStore<T extends StoreKey>(id: T, key: string, value: Store
         return
     }
 
-    const oldValue = clone($[id][key])
+    const oldValue = clone(get($[id])[key])
     const historyValue = { id, key, value, oldValue }
     historyNew("store_update", historyValue)
 }
@@ -40,7 +40,7 @@ export function deleteStore<T extends StoreKey>(id: T, key: string, addToHistory
         return
     }
 
-    const oldValue = clone($[id][key])
+    const oldValue = clone(get($[id])[key])
     const historyValue = { id, key, oldValue }
     historyNew("store_delete", historyValue)
 }

--- a/src/frontend/components/helpers/show.ts
+++ b/src/frontend/components/helpers/show.ts
@@ -384,6 +384,19 @@ export function getLayoutRef(showId = "active", _updater?: Shows | Show) {
     return _show(showId).layouts("active").ref()[0] || []
 }
 
+// a child slide has no "locked" state of its own, so check its parent (group) slide
+export function isSlideLocked(showId: string, slideId: string, _updater?: Shows | Show | null): boolean {
+    const slides = get(showsCache)[showId]?.slides || {}
+    const slide = slides[slideId]
+    if (!slide) return false
+    if (slide.locked) return true
+
+    // child slides are stored in the parent slide's "children" array
+    if (slide.group !== null) return false
+    const parentId = Object.keys(slides).find((id) => slides[id]?.children?.includes(slideId))
+    return !!slides[parentId || ""]?.locked
+}
+
 export function bindSlidesToOutput(indexes: number[], outputId: string) {
     const ref = getLayoutRef()
     const newBindings: string[][] = []

--- a/src/frontend/components/helpers/showActions.ts
+++ b/src/frontend/components/helpers/showActions.ts
@@ -756,6 +756,9 @@ export function getVariablesIds(showAll: boolean = false) {
     return [...variableValues, ...variableSetNameValues, ...randomNumberVariableHistory, ...variableTextSets]
 }
 
+// currently resolving text variables, used to stop circular references
+const resolvingVariables: Set<string> = new Set()
+
 export function getVariableValue(dynamicId: string, ref: any = null): string | string[] {
     if (dynamicId.includes("variable_set_")) {
         const nameId = dynamicId.slice(13)
@@ -802,8 +805,13 @@ export function getVariableValue(dynamicId: string, ref: any = null): string | s
         }
 
         if (variable.enabled === false) return ""
-        if (variable.text?.includes(dynamicId) || !ref) return variable.text || ""
-        return replaceDynamicValues(variable.text || "", ref)
+        // circular references (a variable referencing a variable referencing itself) would recurse forever
+        if (variable.text?.includes(dynamicId) || !ref || resolvingVariables.has(dynamicId)) return variable.text || ""
+
+        resolvingVariables.add(dynamicId)
+        const replacedText = replaceDynamicValues(variable.text || "", ref)
+        resolvingVariables.delete(dynamicId)
+        return replacedText
     }
 
     return ""

--- a/src/frontend/components/slide/Slide.svelte
+++ b/src/frontend/components/slide/Slide.svelte
@@ -16,7 +16,7 @@
     import Icon from "../helpers/Icon.svelte"
     import { getMedia, getMediaCached, getMediaStyle, mediaSize } from "../helpers/media"
     import { allOutputsHasStyleTemplate, getActiveOutputs, getFirstActiveOutput, getResolution, getSlideFilter, setTemplateStyle } from "../helpers/output"
-    import { getGroupName } from "../helpers/show"
+    import { getGroupName, isSlideLocked } from "../helpers/show"
     import { _show } from "../helpers/shows"
     import Effect from "../output/effects/Effect.svelte"
     import SelectElem from "../system/SelectElem.svelte"
@@ -209,7 +209,7 @@
     }
 
     let profile = getAccess("shows")
-    $: isGroupLocked = !!slide?.locked // WIP get group slide
+    $: isGroupLocked = isSlideLocked(showId, layoutSlide.id, show)
     $: isLocked = show?.locked || isGroupLocked || profile.global === "read" || profile[show?.category || ""] === "read"
 
     // correct view order based on arranged order in Items.svelte (?.reverse())
@@ -427,7 +427,7 @@
                         <span class="text" style={name === null || name === "." ? "opacity: 0;" : ""}>{@html name === null || name === "." ? "-" : name || "—"}</span>
 
                         <!-- group is locked! -->
-                        {#if slide.locked || show?.slides?.[layoutSlide?.parent || ""]?.locked}
+                        {#if isGroupLocked}
                             <span class="lock"><Icon id="lock" size={0.7} style="color: var(--text);opacity: 0.3;" white /></span>
                         {/if}
 

--- a/src/frontend/utils/shortcuts.ts
+++ b/src/frontend/utils/shortcuts.ts
@@ -73,7 +73,8 @@ const shiftCtrlKeys = {
 }
 
 const altKeys = {
-    Enter: () => (get(activePage) === "show" ? menuClick("cut_in_half", true, null, null, null, get(selected)) : null)
+    // when the caret is inside a list view textbox, EditboxLines splits at the caret instead
+    Enter: () => (get(activePage) === "show" && !document.activeElement?.closest(".quickEdit") ? menuClick("cut_in_half", true, null, null, null, get(selected)) : null)
 }
 
 export const disablePopupClose = ["initialize", "cloud_method"]


### PR DESCRIPTION
Fifteen focused fixes for show-editing bugs, most of them marked with WIP/TODO comments in the code. Commits are grouped in three areas.

### Text editing / caret

- **Backspace anywhere on a line moved the cursor to the start of the line.** Every Backspace forced a full HTML rebuild of the editbox (the `keyboardLineMutation` path), which destroys the native caret; `setCaret` then failed silently through one of six bare returns — worst being an unconditional bail whenever the box's last line ends in `<br>` (a trailing empty line) and the restore targets line 0. The editbox now only rebuilds when the line/segment structure actually changed (merges/splits), and `setCaret` always positions the range with clamped fallbacks instead of bailing. The guards added for #2748 / #2533 / #2490 / #1427 still apply on structural changes.
- Enter did nothing in an empty textbox, including after undoing into an empty state — `getStyleHtml` now always renders a splittable line block (resolves the WIP note at the top of EditboxLines).
- Enter/Backspace in list view stripped the following text styles — plain mode now maps styles back through identity attributes instead of positional indexes that desync after line count changes.
- Alt+Enter slide split now works in list view (resolves "TODO: get working in list view"); the selection-based `cut_in_half` shortcut is skipped while the caret is inside a quickEdit box, and only the focused editbox instance handles the split.
- Chords duplicated across styled segments (the `data-chords` partition filter's second clause was always true before the last segment) and shifted on mid-line splits (`cutLinesInTwo` reassigned whole-line chords sequentially). Both now partition by character position; relates to #3347.

### Style tools

- Pasting item style to multiple items applied styles to the wrong items — `setItemStyle` reversed `items` but not `values` (the "fix items swapping positions!" workaround was the actual mispairing bug).
- Changing a style with multiple non-text items selected replaced every item's whole style string, position included, with the last selected item's — now merges the changed key into each item's own style.
- Editing the default "Name" overlay swapped textbox contents — the overlay/template apply block now pairs each selected item with its own computed value; the find-a-non-string guard that performed the swap is gone, and lineless text items receive their style string instead of corrupting neighbors.
- Empty textboxes never received style changes (`addStyle` dropped zero-length covered nodes and restored the old style).
- Font-size on a partial selection while auto size is enabled was invisible — it now disables auto size (toast + separate undo entries) and applies the size.
- Auto size measured with forced `center`, which is half-blind to overflow (`scrollHeight` cannot see overflow above the box) — it measures with `flex-start` now; vertical alignment does not affect content size, so computed fits are unchanged for top/center.
- Small ones: slide index 0 treated as falsy in three places, `offsetTop || 5 - 5` operator precedence in the slide list autoscroll, and `$activeEdit.items` being mutated in place by sort/reverse/push.

### Locks, history/undo, stability

- **Locking a group did not lock its child slides** — children never carry `locked`. A new `isSlideLocked` helper in `helpers/show.ts` resolves the parent group and is used in Editbox, SlideEditor, quick edit (Slide), slide-style paste, and EditTools (which had its own inline version).
- **"Maximum call stack size exceeded"** (the TODO above `getTempItems`) was actually circular text-variable references: `getVariableValue` ⇄ `replaceDynamicValues` only guarded direct self-reference, so two variables referencing each other recursed on every render. A resolving-set guard returns the raw text instead of freezing. Also fixed a TypeError for stage slide offsets beyond the generated temp slides.
- History entries changing different style keys no longer coalesce into one — changing font size then color now undoes as two steps; previously the earlier change's undo data was lost (resolves "TODO: slide text edit, dont override different style keys!").
- No-change entries are skipped and no longer clear the redo stack (resolves "TODO: remove history obj if oldData is exactly the same as newdata").
- Undo support for deleting actions, variables, and interactions, and for duplicating projects. This surfaced a bug in `historyStores.ts` where `oldValue` was read off the Writable store object instead of its value, so variable-edit undo restored `undefined` — fixed. Folder duplication is documented as intentionally undo-less (recursive tree duplication has no batch history entry; per-item entries could partially undo into orphaned children — deleting the copy has undo).

### Notes for review

- Behavior notes: duplicated projects now open via the project updater's select hook (same as the other duplicate paths); an undone MIDI-receive action re-registers its listener on the next edit.
- `svelte-check` error count is identical to `dev` before and after (the 346 pre-existing errors) — no new type errors.
- Manual testing focus: backspace mid-line (especially with a trailing empty line in the box), Enter-then-type on a new line (#2748 regression case), IME composition, list-view split/merge, locked group children, chord split/merge.
- The same commits also exist as three thematic branches on my fork (`fix/editbox-caret-and-text-editing`, `fix/edit-style-tools`, `fix/history-undo-group-locks`) if smaller PRs are preferred.
