### PR TITLE
Fix chords stage display

### DIFF
--- a/src/frontend/components/show/getTextEditor.ts
+++ b/src/frontend/components/show/getTextEditor.ts
@@ -67,9 +67,21 @@ function getItems(items: Item[]) {
                 tempText += txt.value
             })
 
-            // chords (from last in line to first)
-            const sortedChords = line.chords?.sort((a, b) => b.pos - a.pos) || []
-            sortedChords.forEach((chord) => {
+            // Chords: Sort right-to-left by position (b.pos - a.pos).
+            // BUG FIX: When multiple chords share the exact same `pos` (like trailing chords at line end),
+            // inserting right-to-left requires the chord with the HIGHER array index (the second chord)
+            // to be inserted FIRST. When the first chord is then inserted at position 5 second,
+            // it lands in front of the second chord, producing something like "[D][C]" instead of "[C][D]".
+            const sortedChords = (line.chords || [])
+                .map((chord, originalIndex) => ({ chord, originalIndex }))
+                .sort((a, b) => {
+                    if (b.chord.pos !== a.chord.pos) {
+                        return b.chord.pos - a.chord.pos
+                    }
+                    return b.originalIndex - a.originalIndex
+                })
+
+            sortedChords.forEach(({ chord }) => {
                 while (!tempText[chord.pos]) tempText += " "
                 tempText = tempText.slice(0, chord.pos) + `[${chord.key}]` + tempText.slice(chord.pos)
             })

--- a/src/frontend/components/slide/TextboxLines.svelte
+++ b/src/frontend/components/slide/TextboxLines.svelte
@@ -202,8 +202,17 @@
                 })
             })
 
-            chords.forEach((chord, i) => {
-                html += `<span class="chord end" data-autosize-ratio="${autosizeRatio}" style="transform: translateX(calc(${1.4 * (i + 1)}em - 50%));">${chord.key}</span>`
+            // Add leading offset before the first end chord to separate it from the last lyric character
+            if (chords.length > 0) {
+                const leadWidthEm = (0.8 * autosizeRatio).toFixed(2)
+                html += `<span class="invisible trailing-lead-space" style="display: inline-block; width: ${leadWidthEm}em; white-space: nowrap;"></span>`
+            }
+
+            // Dynamically reserve inline horizontal space per trailing chord with generous spacing
+            chords.forEach((chord) => {
+                html += `<span class="chord end" data-autosize-ratio="${autosizeRatio}">${chord.key}</span>`
+                const widthEm = Math.max(1.5, (chord.key.length * 0.65 * autosizeRatio) + 0.8).toFixed(2)
+                html += `<span class="invisible trailing-space" style="display: inline-block; width: ${widthEm}em; white-space: nowrap;"></span>`
             })
 
             if (!html) return
@@ -213,7 +222,7 @@
     }
 
     function getLineText(line) {
-        return line.text?.reduce((value, text) => (value += text.value || ""), "") || ""
+        return line.text?.reduce((value, text) => (value += text.value.trim() || ""), "") || ""
     }
 
     function getChordOnlyHtml(chords) {

--- a/src/frontend/components/slide/TextboxLines.svelte
+++ b/src/frontend/components/slide/TextboxLines.svelte
@@ -222,7 +222,7 @@
     }
 
     function getLineText(line) {
-        return line.text?.reduce((value, text) => (value += text.value.trim() || ""), "") || ""
+        return line.text?.reduce((value, text) => (value += text.value || ""), "") || ""
     }
 
     function getChordOnlyHtml(chords) {


### PR DESCRIPTION
Fix trailing chord spacing and alignment, trailing chords appeared higher up than others in stage display

Multiple trailing chords were getting crammed together

Text editor was reversing the order of trailing chords when there was more than 1 trailing chord