### PR TITLE
Scripture history across translations, with the drawer following along

### DIFF
--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -11,6 +11,7 @@
     import { translateText } from "../../../utils/language"
     import { clone } from "../../helpers/array"
     import { brightenDarkColor, fadeColor } from "../../helpers/color"
+    import { setDrawerTabData } from "../../helpers/historyHelpers"
     import Icon from "../../helpers/Icon.svelte"
     import T from "../../helpers/T.svelte"
     import FloatingInputs from "../../input/FloatingInputs.svelte"
@@ -448,7 +449,41 @@
     /// HISTORY ///
 
     let historyOpened = false
-    $: currentHistory = clone($scriptureHistory.filter((a) => a.id === previewBibleId)).reverse()
+    $: currentHistory = clone($scriptureHistory).reverse()
+
+    function openHistoryEntry(verse) {
+        const targetTabId = getHistoryTabId(verse)
+
+        if (!targetTabId || targetTabId === activeScriptureId) {
+            // same translation (or tab no longer exists)
+            openBook(verse.book, [verse.chapter], [verse.verse])
+            playWhenLoaded = true
+            return
+        }
+
+        // if the entry's version is inside a collection, preview that version so
+        // the recorded book numbering matches the previewed bible
+        const collection = $scriptures[targetTabId]?.collection
+        const versionIndex = collection?.versions?.indexOf(verse.id) ?? -1
+        if (versionIndex > -1 && (collection?.previewIndex || 0) !== versionIndex) {
+            scriptures.update((a) => {
+                a[targetTabId].collection!.previewIndex = versionIndex
+                return a
+            })
+        }
+
+        // switch the drawer tab first, then navigate once the new translation is loaded
+        setDrawerTabData("scripture", targetTabId)
+        openScripture.set({ book: verse.book, chapter: verse.chapter, verses: verse.verse, play: true })
+    }
+
+    function getHistoryTabId(verse) {
+        if (verse.tabId && $scriptures[verse.tabId]) {
+            if (verse.tabId === verse.id || $scriptures[verse.tabId].collection?.versions?.includes(verse.id)) return verse.tabId
+        }
+        if ($scriptures[verse.id]) return verse.id
+        return Object.keys($scriptures).find((tabId) => $scriptures[tabId]?.collection?.versions?.includes(verse.id)) || ""
+    }
 
     /// AUTOSCROLL ///
 
@@ -1027,16 +1062,12 @@
             {#if currentHistory.length}
                 <div class="verses verseList">
                     {#each currentHistory as verse}
-                        <span
-                            class="verse"
-                            class:showAllText={$resized.rightPanelDrawer <= 5}
-                            on:dblclick={() => {
-                                openBook(verse.book, [verse.chapter], [verse.verse])
-                                playWhenLoaded = true
-                            }}
-                            data-title={formatBibleText(verse.text)}
-                        >
-                            <span style="width: 250px;text-align: start;color: var(--text);" class="v">{verse.reference}</span>{@html formatBibleText(verse.text, true)}
+                        {@const versionName = verse.version || $scriptures[verse.tabId || verse.id]?.customName || $scriptures[verse.tabId || verse.id]?.name || ""}
+                        <span class="verse" class:showAllText={$resized.rightPanelDrawer <= 5} on:dblclick={() => openHistoryEntry(verse)} data-title={formatBibleText(verse.text)}>
+                            <span style="width: 250px;text-align: start;color: var(--text);" class="v">
+                                {verse.reference}
+                                {#if versionName}<span class="history-version">{versionName}</span>{/if}
+                            </span>{@html formatBibleText(verse.text, true)}
                         </span>
                     {/each}
                 </div>
@@ -1436,6 +1467,16 @@
     }
 
     /* Version */
+
+    .history-version {
+        margin-inline-start: 8px;
+        padding: 1px 8px;
+        border-radius: 15px;
+        border: 1px solid var(--primary-lighter);
+        background-color: var(--primary-darkest);
+        color: var(--secondary);
+        font-size: 0.75em;
+    }
 
     .version {
         flex: 1;

--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -22,7 +22,7 @@
     import TextInput from "../../inputs/TextInput.svelte"
     import Loader from "../../main/Loader.svelte"
     import Center from "../../system/Center.svelte"
-    import { createScriptureShow, formatBibleText, getVerseIdParts, getVersePartLetter, joinRange, loadJsonBible, moveSelection, outputIsScripture, playScripture, scriptureRangeSelect, sortScriptureSelection, splitText, swapPreviewBible } from "./scripture"
+    import { createScriptureShow, formatBibleText, getShortBibleName, getVerseIdParts, getVersePartLetter, joinRange, loadJsonBible, moveSelection, outputIsScripture, playScripture, scriptureRangeSelect, sortScriptureSelection, splitText, swapPreviewBible } from "./scripture"
 
     export let active: string | null
     export let searchValue: string
@@ -450,39 +450,25 @@
 
     let historyOpened = false
     $: currentHistory = clone($scriptureHistory).reverse()
+    $: sameHistoryVersions = currentHistory.map((a) => a.version).every((v, _i, arr) => v === arr[0])
 
-    function openHistoryEntry(verse) {
-        const targetTabId = getHistoryTabId(verse)
+    function openHistoryEntry(item) {
+        let targetTabId = item.tabId
+        if (!$scriptures[targetTabId]) targetTabId = item.id
+        if (!$scriptures[targetTabId]) return // tab no longer exists
 
-        if (!targetTabId || targetTabId === activeScriptureId) {
-            // same translation (or tab no longer exists)
-            openBook(verse.book, [verse.chapter], [verse.verse])
-            playWhenLoaded = true
-            return
-        }
+        const isOpen = targetTabId === activeScriptureId
+        // if (isOpen) {
+        //     openBook(item.book, [item.chapter], [item.verse])
+        //     playWhenLoaded = true
+        //     return
+        // }
 
-        // if the entry's version is inside a collection, preview that version so
-        // the recorded book numbering matches the previewed bible
-        const collection = $scriptures[targetTabId]?.collection
-        const versionIndex = collection?.versions?.indexOf(verse.id) ?? -1
-        if (versionIndex > -1 && (collection?.previewIndex || 0) !== versionIndex) {
-            scriptures.update((a) => {
-                a[targetTabId].collection!.previewIndex = versionIndex
-                return a
-            })
-        }
+        // switch the drawer tab
+        if (!isOpen) setDrawerTabData("scripture", targetTabId)
 
-        // switch the drawer tab first, then navigate once the new translation is loaded
-        setDrawerTabData("scripture", targetTabId)
-        openScripture.set({ book: verse.book, chapter: verse.chapter, verses: verse.verse, play: true })
-    }
-
-    function getHistoryTabId(verse) {
-        if (verse.tabId && $scriptures[verse.tabId]) {
-            if (verse.tabId === verse.id || $scriptures[verse.tabId].collection?.versions?.includes(verse.id)) return verse.tabId
-        }
-        if ($scriptures[verse.id]) return verse.id
-        return Object.keys($scriptures).find((tabId) => $scriptures[tabId]?.collection?.versions?.includes(verse.id)) || ""
+        // navigate (once loaded)
+        openScripture.set({ book: item.book, chapter: item.chapter, verses: item.verse, play: true })
     }
 
     /// AUTOSCROLL ///
@@ -1061,13 +1047,13 @@
         {:else if historyOpened}
             {#if currentHistory.length}
                 <div class="verses verseList">
-                    {#each currentHistory as verse}
-                        {@const versionName = verse.version || $scriptures[verse.tabId || verse.id]?.customName || $scriptures[verse.tabId || verse.id]?.name || ""}
-                        <span class="verse" class:showAllText={$resized.rightPanelDrawer <= 5} on:dblclick={() => openHistoryEntry(verse)} data-title={formatBibleText(verse.text)}>
-                            <span style="width: 250px;text-align: start;color: var(--text);" class="v">
-                                {verse.reference}
-                                {#if versionName}<span class="history-version">{versionName}</span>{/if}
-                            </span>{@html formatBibleText(verse.text, true)}
+                    {#each currentHistory as item}
+                        <span class="verse" class:showAllText={$resized.rightPanelDrawer <= 5} on:dblclick={() => openHistoryEntry(item)} data-title={formatBibleText(item.text)}>
+                            <span style="width: 250px;text-align: start;color: var(--text);{!sameHistoryVersions && item.version ? 'padding-left: 0;' : ''}" class="v">
+                                {#if !sameHistoryVersions && item.version}<span class="v history-version">{getShortBibleName(item.version)}</span>{/if}
+                                {item.reference}
+                            </span>
+                            {@html formatBibleText(item.text, true)}
                         </span>
                     {/each}
                 </div>
@@ -1468,16 +1454,6 @@
 
     /* Version */
 
-    .history-version {
-        margin-inline-start: 8px;
-        padding: 1px 8px;
-        border-radius: 15px;
-        border: 1px solid var(--primary-lighter);
-        background-color: var(--primary-darkest);
-        color: var(--secondary);
-        font-size: 0.75em;
-    }
-
     .version {
         flex: 1;
         padding: 0 10px;
@@ -1527,5 +1503,21 @@
         font-weight: normal;
         padding: 0 !important;
         margin: 0 !important;
+    }
+
+    /* history */
+
+    .history-version {
+        color: var(--text) !important;
+
+        margin-right: 5px !important;
+        width: initial !important;
+        min-width: 45px;
+
+        border: 1px solid var(--primary-lighter);
+        background-color: var(--primary-darkest);
+        font-size: 0.7em;
+        border-radius: 20px;
+        opacity: 0.9;
     }
 </style>

--- a/src/frontend/components/drawer/bible/scripture.ts
+++ b/src/frontend/components/drawer/bible/scripture.ts
@@ -296,10 +296,12 @@ export async function playScripture() {
     scriptureHistory.update((a) => {
         const tabId = get(drawerTabsData).scripture?.activeSubTab || ""
         const tabData = get(scriptures)[tabId]
+        const version = tabData?.customName || tabData?.name || biblesContent[0].version || ""
+
         const newItem = {
+            tabId, // can be a collection
+            version,
             id: biblesContent[0].id,
-            tabId,
-            version: tabData?.customName || tabData?.name || biblesContent[0].version || "",
             book: biblesContent[0].bookId,
             chapter: biblesContent[0].chapters[0],
             verse: selectedVerses[0],

--- a/src/frontend/components/drawer/bible/scripture.ts
+++ b/src/frontend/components/drawer/bible/scripture.ts
@@ -294,8 +294,12 @@ export async function playScripture() {
 
     // scripture usage history
     scriptureHistory.update((a) => {
+        const tabId = get(drawerTabsData).scripture?.activeSubTab || ""
+        const tabData = get(scriptures)[tabId]
         const newItem = {
             id: biblesContent[0].id,
+            tabId,
+            version: tabData?.customName || tabData?.name || biblesContent[0].version || "",
             book: biblesContent[0].bookId,
             chapter: biblesContent[0].chapters[0],
             verse: selectedVerses[0],


### PR DESCRIPTION
### Problem

The drawer's scripture history is stored globally, but the view filters it to the currently previewed translation. In practice that makes history feel broken: play a few verses, switch translation, open history — and everything you just played is gone. During a live service, where switching translations mid-flow is common, the moment you most need "what did I just show?" is exactly when the list comes up empty.

### What this does

- **History is one list across all translations**, newest first, with each entry showing a small secondary-colored pill for the translation it was played from.
- **Double-clicking an entry from another translation makes the drawer follow along**: it switches to that translation's tab (restoring the previewed version if the entry came from inside a collection), navigates to the verse, and plays it — same behavior as before for entries in the current translation.

### How

Small, additive change reusing existing plumbing — no new stores or navigation paths:

- `playScripture()` now also records the drawer tab id and the translation's display name (`customName || name`) on each history entry. The tab id matters for collections, where the entry's bible id is the collection's first version rather than the tab itself.
- The cross-translation jump uses the existing `setDrawerTabData("scripture", ...)` → `openScripture` channel, so load ordering and play semantics are exactly the paths already exercised elsewhere.
- Entries whose translation was since deleted fall back to opening in the current tab; entries recorded before this change (same session) resolve their label via a `$scriptures` lookup.
- Dedup behavior is preserved: replaying a verse from the same tab moves its entry to the top, while the same verse in a different translation is its own labeled entry.

History remains in-memory per session, as before — cleared on restart, so the list stays well within a sane size for any live event.

### Tested

- Verses played across two translations plus a collection: entries appear once each with correct labels; activating cross-translation entries switches the tab, restores the collection's previewed version, and plays the right text.
- Same-translation activation, Ctrl+H toggle, and the grid/list toggle behave as before; the deleted-translation fallback produces no errors.
