### PR TITLE
Update edited slide content in place on output refresh (no blink)

### DIFF
--- a/src/frontend/components/output/layers/SlideContent.svelte
+++ b/src/frontend/components/output/layers/SlideContent.svelte
@@ -225,6 +225,26 @@
         let currentTransitionDuration = transitionEnabled ? (itemTransitionDuration ?? currentTransition?.duration ?? 0) : 0
         let waitToShow = currentTransitionDuration * ((currentTransition?.fadeInOffset ?? 50) / 100)
 
+        const isDifferentSlide = current.currentSlide?.id !== currentSlide?.id || current.outSlide?.index !== outSlide?.index || current.outSlide?.id !== outSlide?.id
+
+        // SAME SLIDE CONTENT REFRESH (e.g. slide edited & re-outputted):
+        // update the items in place without any out/in transition (prevents content blinking)
+        const itemsContentChanged = JSON.stringify(current.currentSlide?.items) !== JSON.stringify(currentSlide.items)
+        if (!isDifferentSlide && itemsContentChanged && show && currentItems.length && currentSlide.items.length) {
+            if (timeout) clearTimeout(timeout)
+            updateGeneration++
+            currentItems = clone(currentSlide.items || [])
+            current = {
+                outSlide: clone(outSlide),
+                slideData: clone(slideData),
+                currentSlide: clone(currentSlide),
+                lines: clone(lines),
+                currentStyle: clone(currentStyle)
+            }
+            transitioningBetween = false
+            return
+        }
+
         // Identify items that are unchanged and have no real transition (to skip redraw)
         const newPersistentIndexes: number[] = []
         const newPersistentItems: Item[] = []
@@ -261,7 +281,6 @@
         persistentItems = newPersistentItems
 
         // between
-        const isDifferentSlide = current.currentSlide?.id !== currentSlide?.id || current.outSlide?.index !== outSlide?.index || current.outSlide?.id !== outSlide?.id
         if (isDifferentSlide && currentItems.length && currentSlide.items.length) transitioningBetween = true
 
         if (timeout) clearTimeout(timeout)

--- a/src/frontend/components/output/transitions/SlideItemTransition.svelte
+++ b/src/frontend/components/output/transitions/SlideItemTransition.svelte
@@ -28,9 +28,22 @@
     function startTransition() {
         // prevent stacking of the same item on update
         const lastStateId = Object.keys(currentlyTransitioning).pop()
-        if (lastStateId) {
-            const lastState = currentlyTransitioning[lastStateId]
+        const lastState = lastStateId ? currentlyTransitioning[lastStateId] : null
+        if (lastState) {
             if (JSON.stringify(lastState.item) === JSON.stringify(item) && JSON.stringify(lastState.lines) === JSON.stringify(lines) && JSON.stringify(lastState.outSlide) === JSON.stringify(outSlide) && JSON.stringify(lastState.currentSlide) === JSON.stringify(currentSlide)) {
+                return
+            }
+
+            // same slide with only updated item content (content refresh): swap the item in place with no transition
+            const sameSlide = lastState.outSlide?.id === outSlide?.id && lastState.outSlide?.index === outSlide?.index && lastState.currentSlide?.id === currentSlide?.id
+            const sameReveal = lastState.outSlide?.line === outSlide?.line && lastState.outSlide?.revealCount === outSlide?.revealCount && lastState.outSlide?.itemClickReveal === outSlide?.itemClickReveal
+            const sameLines = JSON.stringify(lastState.lines) === JSON.stringify(lines)
+            if (sameSlide && sameReveal && sameLines) {
+                Object.keys(currentlyTransitioning).forEach((id) => {
+                    currentlyTransitioning[id] = { ...currentlyTransitioning[id], item: clone(item), currentSlide: clone(currentSlide) }
+                })
+                currentlyTransitioning = currentlyTransitioning
+                currentOut = clone(currentlyTransitioning) // updateOut() only reacts to new state ids
                 return
             }
         }


### PR DESCRIPTION
## Problem

When a slide is edited and then re-clicked in the slides view (or refreshed with Ctrl+R) to push the update to the live output, the output "blinks": the old content fades out, the screen goes blank for a moment, then the new content fades in — instead of just updating the text in place.

This happens regardless of transition settings — even with the transition set to "none" the output still blinked, so no configuration could avoid it (see Cause).

## Cause

The refresh re-sends the same slide, and because the edited items fail the byte-identical `itemsAreEqual` check in `SlideContent.svelte` (and any real transition disables the persistent-items path entirely), every item goes through the full `show = false` → wait `waitToShow` → `show = true` cycle. The `{#key show}` block then tears down and remounts the whole item subtree, producing the fade-out / blank gap / fade-in.

The teardown cycle is unconditional — a "none"/zero-duration transition only removes the fade, not the cycle itself:
- `show = false` → content swap → `show = true` run in a chain of nested `setTimeout`s, so the items are fully unmounted for several macrotasks (a few blank frames minimum) even at duration 0.
- Auto-sized text without a cached font size gets a ~500ms in/out delay in `SlideItemTransition` (coerced to a 1ms fade so the delay still applies), keeping the remounted item invisible for up to half a second even with "none".

## Fix

- **SlideContent.svelte**: when the *same* slide (same show id, layout, index) is re-sent with changed item content, update `currentItems` in place and return before the show/hide cycle — no teardown, no transition. Guards keep everything else unchanged: different slides still transition normally, line/reveal clicks still animate, empty-slide clearing is untouched, and a refresh landing mid-transition (`show === false`) falls through to the normal cycle.
- **SlideItemTransition.svelte**: since the wrapper is no longer torn down in this case, content-only updates on the same slide now swap the item into the existing transition state instead of minting a new crossfading state (which would have stacked old + new content).

Because nothing is unmounted, this sidesteps both structural causes at once: no blank frames from the timer chain, and the auto-size hide delay never triggers on refresh (worst case the visible textbox re-measures in place). Media items keep their DOM element on refresh, so background/item videos no longer restart when a slide is refreshed.

## Testing

Checked so far: prettier, eslint, and svelte-check are clean, and the production frontend build passes.

Manual verification steps:
- Edit a text slide and re-click it in Show view → should update in place, no blink (output window + preview)
- Ctrl+R refresh after edit → same in-place update
- Click a different slide → normal transition plays as before
- Line/reveal clicks on the same slide → animate as before
- Transition set to "none" → still updates in place
- Slide with a background video → refresh must not restart the video
