### PR TITLE
Auto size text resizes while typing instead of jumping after a delay

### DIFF
--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -744,7 +744,7 @@
                 on:mouseup={() => storeCurrentCaretPos()}
                 class="edit context {plain ? '#editbox_text' : '#edit_box__editbox_text'}"
                 class:hidden={chordsMode}
-                class:autoSize={isAuto && autoSize}
+                class:autoSize={isAuto && autoSize && !plain}
                 contenteditable
                 on:keydown={textElemKeydown}
                 on:input={() => scheduleAutoSize()}
@@ -757,7 +757,7 @@
                 on:copy={handleCopy}
                 on:cut={handleCut}
                 bind:innerHTML={html}
-                style="{plain || !isAuto ? '' : `--auto-size: ${autoSize}px;`}{!plain ? lineStyleBox : ''}{plain ? '' : typeof item.align === 'string' ? item.align.replace('align-items', 'justify-content') : ''}"
+                style="{isAuto && autoSize && !plain ? `--auto-size: ${autoSize}px;` : ''}{!plain ? lineStyleBox : ''}{plain ? '' : typeof item.align === 'string' ? item.align.replace('align-items', 'justify-content') : ''}"
                 class:height={item.lines?.length < 2 && !item.lines?.[0]?.text[0]?.value.length}
                 class:tallLines={chordsMode}
             />

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-    import { onMount, tick } from "svelte"
+    import { onDestroy, onMount, tick } from "svelte"
     import { uid } from "uid"
     import type { Item, Line } from "../../../../types/Show"
     import { splitCustomDynamicValues } from "../../../show/slides"
-    import { activeEdit, activeShow, activeStage, overlays, redoHistory, refreshListBoxes, showsCache, stageShows, templates } from "../../../stores"
+    import { activeEdit, activeShow, activeStage, overlays, redoHistory, refreshListBoxes, showsCache, special, stageShows, templates } from "../../../stores"
     import { newToast } from "../../../utils/common"
     import { getNormalizedKey, isComposing, isFormattingKey } from "../../../utils/shortcuts"
     import T from "../../helpers/T.svelte"
@@ -45,12 +45,18 @@
 
         setTimeout(() => {
             loaded = true
+            // instant first paint from the stored output size, then always verify against the editor DOM
+            // (that value is measured with different selectors/ratios, so it is only approximate here)
             autoSize = item?.autoFontSize || 0
-            if (autoSize) return
 
-            getCustomAutoSize()
+            scheduleAutoSize(true)
+
+            // measuring before a webfont has loaded gives a wrong size, and nothing else would re-trigger it
+            document.fonts?.ready?.then(() => scheduleAutoSize(true))
         }, 50)
     })
+
+    onDestroy(cancelScheduledAutoSize)
 
     // prevent certain updates during IME composition to prevent text deselecting and double-insertion.
     let composing = false
@@ -354,67 +360,94 @@
 
     // AUTO SIZE
 
-    // text change
-    let textChanged = false
-    let previousText = ""
-    let changedTimeout: NodeJS.Timeout | null = null
-    $: if (html && textElem?.innerText !== previousText) checkText()
-    function checkText() {
-        textChanged = true
-        previousText = textElem?.innerText || ""
-        if (changedTimeout) clearTimeout(changedTimeout)
-        changedTimeout = setTimeout(() => (textChanged = false), 500)
-    }
-
-    let isTyping = false
-    $: if (isAuto && textChanged) checkTyping()
-    let typingTimeout: NodeJS.Timeout | null = null
-    function checkTyping() {
-        if (!loaded) return
-        isTyping = true
-
-        if (typingTimeout) clearTimeout(typingTimeout)
-        typingTimeout = setTimeout(() => {
-            isTyping = false
-            if (isAuto) getCustomAutoSize()
-        }, 800)
-    }
-
-    // update auto size
     let loaded = false
     $: isAuto = item?.auto || (item?.textFit || "none") !== "none"
     $: textArray = Array.isArray(item?.lines?.[0]?.text) ? item.lines[0].text : []
     $: itemText = textArray.filter((a) => !a.customType?.includes("disableTemplate")) || []
     $: itemFontSize = Number(getStyles((ref.type === "stage" ? item : itemText[0])?.style, true)?.["font-size"] || "")
     $: itemStyle = item?.style
-    $: if (itemStyle && (isAuto || itemFontSize || textChanged)) getCustomAutoSize()
+    // html updates on every keystroke (bind:innerHTML), so this covers typing, pasting and style rebuilds,
+    // itemStyle covers resizing the textbox and lineGap the line spacing
+    $: if (html || itemStyle || isAuto || itemFontSize || lineGap) scheduleAutoSize()
 
     let autoSize = 0
     let alignElem: HTMLElement | undefined
+
+    // a measurement is a DOM clone + ~9 forced layouts (~0.3ms for a full slide of text),
+    // so cap it at one per frame while typing and drop to a trailing debounce if one ever gets expensive
+    const SLOW_MEASURE_MS = 6
+    const DEBOUNCE_MS = 150
+
+    let autoSizeFrame = 0
     let autosizeTimeout: NodeJS.Timeout | null = null
-    function getCustomAutoSize() {
-        if (isTyping || !loaded || !alignElem || !isAuto) return
+    let lastMeasureDuration = 0
+    let lastSignature = ""
 
-        if (autosizeTimeout) clearTimeout(autosizeTimeout)
-        autosizeTimeout = setTimeout(() => {
+    function scheduleAutoSize(immediate = false) {
+        // plain (list) view never renders --auto-size
+        if (plain || !loaded || !isAuto || !alignElem || composing) return
+
+        if (immediate) {
+            cancelScheduledAutoSize()
+            runAutoSize()
+            return
+        }
+
+        // chords rebuild one span per character whenever the size changes, so never run those per frame
+        if (chordsMode || lastMeasureDuration > SLOW_MEASURE_MS || $special.optimizedMode) {
+            if (autosizeTimeout) clearTimeout(autosizeTimeout)
+            autosizeTimeout = setTimeout(() => {
+                autosizeTimeout = null
+                runAutoSize()
+            }, DEBOUNCE_MS)
+            return
+        }
+
+        if (autoSizeFrame) return
+        autoSizeFrame = requestAnimationFrame(() => {
+            autoSizeFrame = 0
+            runAutoSize()
+        })
+    }
+
+    function cancelScheduledAutoSize() {
+        if (autoSizeFrame) {
+            cancelAnimationFrame(autoSizeFrame)
+            autoSizeFrame = 0
+        }
+        if (autosizeTimeout) {
+            clearTimeout(autosizeTimeout)
             autosizeTimeout = null
-            if (!alignElem) return
+        }
+    }
 
-            if (ref.type === "stage") {
-                itemFontSize = Number(getStyles(item?.style, true)?.["font-size"] || "")
-            }
+    function runAutoSize() {
+        if (plain || !loaded || !alignElem || !isAuto) return
+        // element is mid remount
+        if (!alignElem.clientHeight) return
 
-            let type = item?.textFit || "shrinkToFit"
-            let defaultFontSize = itemFontSize
-            let maxFontSize
+        if (ref.type === "stage") {
+            itemFontSize = Number(getStyles(item?.style, true)?.["font-size"] || "")
+        }
 
-            if (type === "growToFit") {
-                defaultFontSize = 100
-                maxFontSize = itemFontSize
-            }
+        const type = item?.textFit || "shrinkToFit"
 
-            autoSize = autosize(alignElem, { type, textQuery: ".edit .break span", defaultFontSize, maxFontSize })
-        }, 50)
+        // skip repeated triggers that can't change the result (e.g. a new item object with identical content)
+        const signature = `${alignElem.clientWidth}x${alignElem.clientHeight}|${itemFontSize}|${type}|${lineGap || 0}|${html}`
+        if (signature === lastSignature) return
+        lastSignature = signature
+
+        let defaultFontSize = itemFontSize
+        let maxFontSize
+
+        if (type === "growToFit") {
+            defaultFontSize = 100
+            maxFontSize = itemFontSize
+        }
+
+        const measureStart = performance.now()
+        autoSize = autosize(alignElem, { type, textQuery: ".edit .break span", defaultFontSize, maxFontSize })
+        lastMeasureDuration = performance.now() - measureStart
     }
 
     // UPDATE STYLE FROM LINES
@@ -726,8 +759,12 @@
                 class:autoSize={item.auto && autoSize}
                 contenteditable
                 on:keydown={textElemKeydown}
+                on:input={() => scheduleAutoSize()}
                 on:compositionstart={() => (composing = true)}
-                on:compositionend={() => (composing = false)}
+                on:compositionend={() => {
+                    composing = false
+                    scheduleAutoSize(true)
+                }}
                 on:blur={() => (composing = false)}
                 on:copy={handleCopy}
                 on:cut={handleCut}

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -45,13 +45,11 @@
 
         setTimeout(() => {
             loaded = true
-            // instant first paint from the stored output size, then always verify against the editor DOM
-            // (that value is measured with different selectors/ratios, so it is only approximate here)
             autoSize = item?.autoFontSize || 0
 
             scheduleAutoSize(true)
 
-            // measuring before a webfont has loaded gives a wrong size, and nothing else would re-trigger it
+            // trigger auto size update after font has loaded
             document.fonts?.ready?.then(() => scheduleAutoSize(true))
         }, 50)
     })
@@ -373,8 +371,7 @@
     let autoSize = 0
     let alignElem: HTMLElement | undefined
 
-    // a measurement is a DOM clone + ~9 forced layouts (~0.3ms for a full slide of text),
-    // so cap it at one per frame while typing and drop to a trailing debounce if one ever gets expensive
+    // cap auto size at one per frame while typing and drop to a trailing debounce if one ever gets expensive
     const SLOW_MEASURE_MS = 6
     const DEBOUNCE_MS = 150
 
@@ -411,14 +408,10 @@
     }
 
     function cancelScheduledAutoSize() {
-        if (autoSizeFrame) {
-            cancelAnimationFrame(autoSizeFrame)
-            autoSizeFrame = 0
-        }
-        if (autosizeTimeout) {
-            clearTimeout(autosizeTimeout)
-            autosizeTimeout = null
-        }
+        if (autoSizeFrame) cancelAnimationFrame(autoSizeFrame)
+        if (autosizeTimeout) clearTimeout(autosizeTimeout)
+        autoSizeFrame = 0
+        autosizeTimeout = null
     }
 
     function runAutoSize() {
@@ -437,13 +430,8 @@
         if (signature === lastSignature) return
         lastSignature = signature
 
-        let defaultFontSize = itemFontSize
-        let maxFontSize
-
-        if (type === "growToFit") {
-            defaultFontSize = 100
-            maxFontSize = itemFontSize
-        }
+        const defaultFontSize = type === "growToFit" ? 100 : itemFontSize
+        const maxFontSize = type === "growToFit" ? itemFontSize : undefined
 
         const measureStart = performance.now()
         autoSize = autosize(alignElem, { type, textQuery: ".edit .break span", defaultFontSize, maxFontSize })

--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -744,7 +744,7 @@
                 on:mouseup={() => storeCurrentCaretPos()}
                 class="edit context {plain ? '#editbox_text' : '#edit_box__editbox_text'}"
                 class:hidden={chordsMode}
-                class:autoSize={item.auto && autoSize}
+                class:autoSize={isAuto && autoSize}
                 contenteditable
                 on:keydown={textElemKeydown}
                 on:input={() => scheduleAutoSize()}
@@ -757,7 +757,7 @@
                 on:copy={handleCopy}
                 on:cut={handleCut}
                 bind:innerHTML={html}
-                style="{plain || !item.auto ? '' : `--auto-size: ${autoSize}px;`}{!plain ? lineStyleBox : ''}{plain ? '' : typeof item.align === 'string' ? item.align.replace('align-items', 'justify-content') : ''}"
+                style="{plain || !isAuto ? '' : `--auto-size: ${autoSize}px;`}{!plain ? lineStyleBox : ''}{plain ? '' : typeof item.align === 'string' ? item.align.replace('align-items', 'justify-content') : ''}"
                 class:height={item.lines?.length < 2 && !item.lines?.[0]?.text[0]?.value.length}
                 class:tallLines={chordsMode}
             />

--- a/src/frontend/components/edit/editors/SlideEditor.svelte
+++ b/src/frontend/components/edit/editors/SlideEditor.svelte
@@ -167,9 +167,6 @@
         updateTimeout = setTimeout(resetAutoSize, 3000)
 
         function resetAutoSize() {
-            // the editbox re-fits live from the updated item style, this only clears the stored size used
-            // as a first paint value by the previews/output (they self invalidate through buildAutoSizeSignature)
-            // - don't refresh the edit slide, that remounts the editor and drops the caret
             showsCache.update((a) => {
                 if (!a[currentShowId]?.slides?.[slideId]?.items?.[activeItems[0] || 0]?.autoFontSize) return a
 

--- a/src/frontend/components/edit/editors/SlideEditor.svelte
+++ b/src/frontend/components/edit/editors/SlideEditor.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { onMount } from "svelte"
     import type { MediaStyle } from "../../../../types/Main"
-    import { activeEdit, activePopup, activeShow, alertMessage, editMode, focusMode, media, outputs, overlays, playerVideos, refreshEditSlide, resized, showsCache, slideNotesActive, special, styles } from "../../../stores"
+    import { activeEdit, activePopup, activeShow, alertMessage, editMode, focusMode, media, outputs, overlays, playerVideos, resized, showsCache, slideNotesActive, special, styles } from "../../../stores"
     import { transposeText } from "../../../utils/chordTranspose"
     import { DEFAULT_WIDTH } from "../../../utils/common"
     import { translateText } from "../../../utils/language"
@@ -167,14 +167,15 @@
         updateTimeout = setTimeout(resetAutoSize, 3000)
 
         function resetAutoSize() {
+            // the editbox re-fits live from the updated item style, this only clears the stored size used
+            // as a first paint value by the previews/output (they self invalidate through buildAutoSizeSignature)
+            // - don't refresh the edit slide, that remounts the editor and drops the caret
             showsCache.update((a) => {
                 if (!a[currentShowId]?.slides?.[slideId]?.items?.[activeItems[0] || 0]?.autoFontSize) return a
 
                 delete a[currentShowId].slides[slideId].items[activeItems[0] || 0].autoFontSize
                 return a
             })
-
-            refreshEditSlide.set(true)
         }
     }
 

--- a/src/frontend/components/edit/scripts/autosize.ts
+++ b/src/frontend/components/edit/scripts/autosize.ts
@@ -36,86 +36,84 @@ export default function autosize(elem: HTMLElement, { type, textQuery, defaultFo
     const boxElem = virtualElem()
     if (!boxElem) return defaultFontSize
 
-    const boxWidth = boxElem.clientWidth
-    const boxHeight = boxElem.clientHeight
+    // the clone is measured up to once per frame while editing, always remove it (even on a throw)
+    try {
+        const boxWidth = boxElem.clientWidth
+        const boxHeight = boxElem.clientHeight
 
-    let textChildren: HTMLElement[] | HTMLCollection = []
-    if (textQuery) textChildren = boxElem.querySelectorAll(textQuery) as any
-    if (!textChildren.length) textChildren = boxElem.children.length ? boxElem.children : [boxElem]
+        let textChildren: HTMLElement[] | HTMLCollection = []
+        if (textQuery) textChildren = boxElem.querySelectorAll(textQuery) as any
+        if (!textChildren.length) textChildren = boxElem.children.length ? boxElem.children : [boxElem]
 
-    let fontSize = defaultFontSize // maxFontSize * 0.5
-    const styles: string[] = []
-    addStyleToElemText(fontSize)
-
-    if (type === "shrinkToFit") {
-        if (!textIsBiggerThanBox()) {
-            // don't change the font size
-            return finish(defaultFontSize)
-        }
-        // shrinkToFit is same as growToFit if text is larger
-    }
-
-    let lowestValue = minFontSize
-    let highestValue = maxFontSize
-    let previousSize = 0
-
-    size()
-
-    const finalResult = Math.min(maxFontSize, lowestValue)
-
-    // prefer lowest value (due to margin)
-    return finish(finalResult)
-
-    function finish(value: number) {
-        boxElem!.remove()
-        return value
-    }
-
-    function size() {
-        if (textIsBiggerThanBox()) highestValue = fontSize - 1
-        else lowestValue = fontSize
-
-        // if difference is less than 2px margin, return early
-        if (highestValue - lowestValue < PRECISION) return
-
-        // always double/half the amount for the quickest search
-        fontSize = (highestValue + lowestValue) * 0.5
-
-        // prevent loops
-        if (Math.abs(fontSize - previousSize) < 1) return
-        previousSize = fontSize
-
+        let fontSize = defaultFontSize // maxFontSize * 0.5
+        const styles: string[] = []
         addStyleToElemText(fontSize)
-        size()
-    }
 
-    function textIsBiggerThanBox() {
-        return boxElem!.scrollWidth > boxWidth || boxElem!.scrollHeight > boxHeight
-    }
-
-    function addStyleToElemText(currentFontSize: number) {
-        for (const elemWithChordSize of Array.from(boxElem!.querySelectorAll("[data-chord-size-ratio]"))) {
-            const htmlElem = elemWithChordSize as HTMLElement
-            const chordSizeRatio = Number(htmlElem.dataset.chordSizeRatio || "") || 0
-            if (!chordSizeRatio) continue
-
-            htmlElem.style.setProperty("--font-size", `${currentFontSize}px`)
-            htmlElem.style.setProperty("--chord-size", `${currentFontSize * chordSizeRatio}px`)
-        }
-
-        let i = 0
-        for (const textElem of Array.from(textChildren)) {
-            const htmlTextElem = textElem as HTMLElement
-            if (!styles[i]) styles[i] = htmlTextElem.getAttribute("style") || ""
-            const autosizeRatio = Number(htmlTextElem.dataset.autosizeRatio || "") || 1
-            if (styles[i].includes("var(--base-font-size)")) {
-                const newStyle = styles[i].replace(/--base-font-size:\s*[^;]+;?/gi, `--base-font-size: ${currentFontSize * autosizeRatio}px;`)
-                htmlTextElem.setAttribute("style", newStyle + ";overflow:visible;")
-            } else {
-                htmlTextElem.setAttribute("style", styles[i] + `;overflow:visible;font-size: ${currentFontSize * autosizeRatio}px !important;`)
+        if (type === "shrinkToFit") {
+            if (!textIsBiggerThanBox()) {
+                // don't change the font size
+                return defaultFontSize
             }
-            i++
+            // shrinkToFit is same as growToFit if text is larger
         }
+
+        let lowestValue = minFontSize
+        let highestValue = maxFontSize
+        let previousSize = 0
+
+        size()
+
+        // prefer lowest value (due to margin)
+        return Math.min(maxFontSize, lowestValue)
+
+        function size() {
+            if (textIsBiggerThanBox()) highestValue = fontSize - 1
+            else lowestValue = fontSize
+
+            // if difference is less than 2px margin, return early
+            if (highestValue - lowestValue < PRECISION) return
+
+            // always double/half the amount for the quickest search
+            fontSize = (highestValue + lowestValue) * 0.5
+
+            // prevent loops
+            if (Math.abs(fontSize - previousSize) < 1) return
+            previousSize = fontSize
+
+            addStyleToElemText(fontSize)
+            size()
+        }
+
+        function textIsBiggerThanBox() {
+            return boxElem!.scrollWidth > boxWidth || boxElem!.scrollHeight > boxHeight
+        }
+
+        function addStyleToElemText(currentFontSize: number) {
+            for (const elemWithChordSize of Array.from(boxElem!.querySelectorAll("[data-chord-size-ratio]"))) {
+                const htmlElem = elemWithChordSize as HTMLElement
+                const chordSizeRatio = Number(htmlElem.dataset.chordSizeRatio || "") || 0
+                if (!chordSizeRatio) continue
+
+                htmlElem.style.setProperty("--font-size", `${currentFontSize}px`)
+                htmlElem.style.setProperty("--chord-size", `${currentFontSize * chordSizeRatio}px`)
+            }
+
+            let i = 0
+            for (const textElem of Array.from(textChildren)) {
+                const htmlTextElem = textElem as HTMLElement
+                if (!styles[i]) styles[i] = htmlTextElem.getAttribute("style") || ""
+                const autosizeRatio = Number(htmlTextElem.dataset.autosizeRatio || "") || 1
+                if (styles[i].includes("var(--base-font-size)")) {
+                    const newStyle = styles[i].replace(/--base-font-size:\s*[^;]+;?/gi, `--base-font-size: ${currentFontSize * autosizeRatio}px;`)
+                    htmlTextElem.setAttribute("style", newStyle + ";overflow:visible;")
+                } else {
+                    htmlTextElem.setAttribute("style", styles[i] + `;overflow:visible;font-size: ${currentFontSize * autosizeRatio}px !important;`)
+                }
+                i++
+            }
+        }
+    } finally {
+        boxElem.remove()
     }
 
     function virtualElem() {
@@ -126,6 +124,16 @@ export default function autosize(elem: HTMLElement, { type, textQuery, defaultFo
         cloned.style.position = "absolute"
         cloned.style.opacity = "0"
         // overflow = hidden...
+
+        // the editor clones a live contenteditable (measured up to once per frame while typing),
+        // don't let the browser treat the clone as editable/spellcheckable content
+        cloned.setAttribute("contenteditable", "false")
+        cloned.setAttribute("spellcheck", "false")
+        cloned.setAttribute("aria-hidden", "true")
+        for (const editableElem of Array.from(cloned.querySelectorAll("[contenteditable]"))) {
+            editableElem.setAttribute("contenteditable", "false")
+            editableElem.setAttribute("spellcheck", "false")
+        }
 
         // "include" paddings
         const computedStyle = getComputedStyle(elem)

--- a/src/frontend/components/edit/scripts/autosize.ts
+++ b/src/frontend/components/edit/scripts/autosize.ts
@@ -36,80 +36,75 @@ export default function autosize(elem: HTMLElement, { type, textQuery, defaultFo
     const boxElem = virtualElem()
     if (!boxElem) return defaultFontSize
 
-    // the clone is measured up to once per frame while editing, always remove it (even on a throw)
     try {
         const boxWidth = boxElem.clientWidth
         const boxHeight = boxElem.clientHeight
 
-        let textChildren: HTMLElement[] | HTMLCollection = []
-        if (textQuery) textChildren = boxElem.querySelectorAll(textQuery) as any
-        if (!textChildren.length) textChildren = boxElem.children.length ? boxElem.children : [boxElem]
+        const rawTextChildren: HTMLElement[] = textQuery ? Array.from(boxElem.querySelectorAll(textQuery)) : boxElem.children.length ? (Array.from(boxElem.children) as HTMLElement[]) : [boxElem]
 
-        let fontSize = defaultFontSize // maxFontSize * 0.5
-        const styles: string[] = []
+        const chordNodes: { elem: HTMLElement; ratio: number }[] = []
+        boxElem.querySelectorAll<HTMLElement>("[data-chord-size-ratio]").forEach((el) => {
+            const ratio = Number(el.dataset.chordSizeRatio) || 0
+            if (ratio) chordNodes.push({ elem: el, ratio })
+        })
+
+        const textNodes = rawTextChildren.map((el) => {
+            const style = el.getAttribute("style") || ""
+            const ratio = Number(el.dataset.autosizeRatio) || 1
+            const hasBaseFontSize = style.includes("var(--base-font-size)")
+            return { el, style, ratio, hasBaseFontSize }
+        })
+
+        let fontSize = defaultFontSize
         addStyleToElemText(fontSize)
 
-        if (type === "shrinkToFit") {
-            if (!textIsBiggerThanBox()) {
-                // don't change the font size
-                return defaultFontSize
-            }
-            // shrinkToFit is same as growToFit if text is larger
+        if (type === "shrinkToFit" && !textIsBiggerThanBox()) {
+            return defaultFontSize
         }
 
         let lowestValue = minFontSize
         let highestValue = maxFontSize
-        let previousSize = 0
+        let previousSize = fontSize
 
-        size()
+        if (textIsBiggerThanBox()) highestValue = fontSize - 1
+        else lowestValue = fontSize
 
-        // prefer lowest value (due to margin)
-        return Math.min(maxFontSize, lowestValue)
-
-        function size() {
-            if (textIsBiggerThanBox()) highestValue = fontSize - 1
-            else lowestValue = fontSize
-
-            // if difference is less than 2px margin, return early
-            if (highestValue - lowestValue < PRECISION) return
-
+        while (highestValue - lowestValue >= PRECISION) {
             // always double/half the amount for the quickest search
             fontSize = (highestValue + lowestValue) * 0.5
 
-            // prevent loops
-            if (Math.abs(fontSize - previousSize) < 1) return
+            // prevent loops on sub-pixel changes
+            if (Math.abs(fontSize - previousSize) < 1) break
             previousSize = fontSize
 
             addStyleToElemText(fontSize)
-            size()
+
+            if (textIsBiggerThanBox()) highestValue = fontSize - 1
+            else lowestValue = fontSize
         }
+
+        // prefer lowest value (due to margin)
+        return Math.min(maxFontSize, lowestValue)
 
         function textIsBiggerThanBox() {
             return boxElem!.scrollWidth > boxWidth || boxElem!.scrollHeight > boxHeight
         }
 
         function addStyleToElemText(currentFontSize: number) {
-            for (const elemWithChordSize of Array.from(boxElem!.querySelectorAll("[data-chord-size-ratio]"))) {
-                const htmlElem = elemWithChordSize as HTMLElement
-                const chordSizeRatio = Number(htmlElem.dataset.chordSizeRatio || "") || 0
-                if (!chordSizeRatio) continue
-
-                htmlElem.style.setProperty("--font-size", `${currentFontSize}px`)
-                htmlElem.style.setProperty("--chord-size", `${currentFontSize * chordSizeRatio}px`)
+            for (let i = 0; i < chordNodes.length; i++) {
+                chordNodes[i].elem.style.setProperty("--font-size", `${currentFontSize}px`)
+                chordNodes[i].elem.style.setProperty("--chord-size", `${currentFontSize * chordNodes[i].ratio}px`)
             }
 
-            let i = 0
-            for (const textElem of Array.from(textChildren)) {
-                const htmlTextElem = textElem as HTMLElement
-                if (!styles[i]) styles[i] = htmlTextElem.getAttribute("style") || ""
-                const autosizeRatio = Number(htmlTextElem.dataset.autosizeRatio || "") || 1
-                if (styles[i].includes("var(--base-font-size)")) {
-                    const newStyle = styles[i].replace(/--base-font-size:\s*[^;]+;?/gi, `--base-font-size: ${currentFontSize * autosizeRatio}px;`)
-                    htmlTextElem.setAttribute("style", newStyle + ";overflow:visible;")
+            for (let i = 0; i < textNodes.length; i++) {
+                const node = textNodes[i]
+                const size = currentFontSize * node.ratio
+                if (node.hasBaseFontSize) {
+                    const newStyle = node.style.replace(/--base-font-size:\s*[^;]+;?/gi, `--base-font-size: ${size}px;`)
+                    node.el.setAttribute("style", newStyle + ";overflow:visible;")
                 } else {
-                    htmlTextElem.setAttribute("style", styles[i] + `;overflow:visible;font-size: ${currentFontSize * autosizeRatio}px !important;`)
+                    node.el.setAttribute("style", `${node.style};overflow:visible;font-size: ${size}px !important;`)
                 }
-                i++
             }
         }
     } finally {
@@ -125,15 +120,14 @@ export default function autosize(elem: HTMLElement, { type, textQuery, defaultFo
         cloned.style.opacity = "0"
         // overflow = hidden...
 
-        // the editor clones a live contenteditable (measured up to once per frame while typing),
-        // don't let the browser treat the clone as editable/spellcheckable content
+        // don't treat the clone as editable content
         cloned.setAttribute("contenteditable", "false")
         cloned.setAttribute("spellcheck", "false")
         cloned.setAttribute("aria-hidden", "true")
-        for (const editableElem of Array.from(cloned.querySelectorAll("[contenteditable]"))) {
-            editableElem.setAttribute("contenteditable", "false")
-            editableElem.setAttribute("spellcheck", "false")
-        }
+        cloned.querySelectorAll("[contenteditable]").forEach((el) => {
+            el.setAttribute("contenteditable", "false")
+            el.setAttribute("spellcheck", "false")
+        })
 
         // "include" paddings
         const computedStyle = getComputedStyle(elem)
@@ -146,42 +140,30 @@ export default function autosize(elem: HTMLElement, { type, textQuery, defaultFo
         // scrollHeight only measures overflow below the box: with flex-end (and half of it with center) overflow is invisible to it,
         // so measure with flex-start - vertical alignment does not affect the content size, the computed fit is the same
         cloned.style.alignItems = "flex-start"
-        if (cloned.querySelector(".edit")) (cloned.querySelector(".edit") as HTMLElement).style.justifyContent = "flex-start"
+        const editElem = cloned.querySelector<HTMLElement>(".edit")
+        if (editElem) editElem.style.justifyContent = "flex-start"
 
-        for (const elemHide of Array.from(cloned.querySelectorAll(".hideFromAutosize"))) {
-            ;(elemHide as HTMLElement).style.display = "none"
-        }
-
-        // fix chords size
-        for (const chordElem of Array.from(cloned.querySelectorAll(".chords"))) {
-            ;(chordElem as HTMLElement).style.maxHeight = "65px"
-        }
+        cloned.querySelectorAll<HTMLElement>(".hideFromAutosize").forEach((el) => (el.style.display = "none"))
+        cloned.querySelectorAll<HTMLElement>(".chords").forEach((el) => (el.style.maxHeight = "65px"))
 
         // scrolling text should not include repeated text in measurement
-        const scrollWrapper = cloned.querySelector(".scrollWrapper") as HTMLElement
+        const scrollWrapper = cloned.querySelector<HTMLElement>(".scrollWrapper")
         if (scrollWrapper) scrollWrapper.style.setProperty("--copyCountHorizontal", "0")
         // only keep first scrollContent element
-        const scrollContents = cloned.querySelectorAll(".scrollContent")
-        if (scrollContents.length > 1) {
-            scrollContents.forEach((elem, index) => {
-                if (index > 0) elem.remove()
-            })
-        }
+        cloned.querySelectorAll(".scrollContent").forEach((el, index) => {
+            if (index > 0) el.remove()
+        })
 
         // CRITICAL FIX FOR LIST ITEMS:
         // List items have font-size on both the parent .break div AND the inner span elements
         // This causes double font-size application during measurement
         // We need to remove font-size from .break divs so only the spans (selected by textQuery) control sizing
         if (isList) {
-            const breakElements = cloned.querySelectorAll(".break")
-            for (const breakElem of Array.from(breakElements)) {
-                const htmlBreak = breakElem as HTMLElement
-                const currentStyle = htmlBreak.getAttribute("style") || ""
-                const newStyle = currentStyle.replace(/font-size:\s*[^;]+;?/gi, "")
-                htmlBreak.setAttribute("style", newStyle)
-            }
+            cloned.querySelectorAll<HTMLElement>(".break").forEach((el) => {
+                const currentStyle = el.getAttribute("style") || ""
+                el.setAttribute("style", currentStyle.replace(/font-size:\s*[^;]+;?/gi, ""))
+            })
         }
-
         elem.after(cloned)
         return cloned
     }

--- a/src/frontend/components/slide/Textbox.svelte
+++ b/src/frontend/components/slide/Textbox.svelte
@@ -480,7 +480,7 @@
             customTypeRatio = verseItemSize / 100 || 1
 
             defaultFontSize = itemFontSize
-            if (textFit === "growToFit" && isTextItem && itemFontSize > 100) maxFontSize = itemFontSize
+            if (textFit === "growToFit" && isTextItem) maxFontSize = itemFontSize
         }
 
         elem = itemElem


### PR DESCRIPTION
## What

With auto size (`textFit` / legacy `auto`) enabled, text in the slide editor now resizes continuously as you type, instead of jumping once after a delay.

## Why

The recalculation was gated behind an 800 ms typing timer, armed by:

```js
$: if (isAuto && textChanged) checkTyping()
```

`checkText()` runs on every keystroke and sets `textChanged = true`, but Svelte's `safe_not_equal(true, true)` is false, so this reactive statement does **not** re-run and the 800 ms timer is never reset. Per typing burst you get one measurement at t≈800 ms using whatever text existed then, and one catch-up when `textChanged` flips back to `false` ~500 ms after you stop — nothing in between.

The result is a size that lags the text and then snaps, which reads as a glitch rather than as text fitting itself. And anything that didn't change the text, or landed while the timer was pending, needed another keystroke — usually a space — before it showed up.

## How

- Replaced the `textChanged` / `isTyping` / debounce machinery with one `scheduleAutoSize()` that coalesces into a single `requestAnimationFrame` per frame, driven by `html` (which `bind:innerHTML` invalidates on every keystroke) plus an explicit `on:input`. It keeps the `itemStyle` dependency added in 7df0fcda ("Optimized textbox resize"), so resizing the box still re-fits.
- A signature check (`box size | font size | textFit | lineGap | html`) skips triggers that cannot change the result, so idle cost is zero.
- Measurements that turn out to be expensive — or chords mode, where every size change rebuilds one span per character — fall back to a trailing 150 ms debounce. `optimizedMode` always uses it.
- Nothing runs during IME composition; one recalculation on `compositionend`.
- One measurement after `document.fonts.ready` — measuring against a fallback font gave a wrong size that nothing would re-trigger.
- `onMount` no longer returns early on a stored `autoFontSize`. That value is measured from the output DOM with different selectors and ratios, so it's only good as a first-paint seed.
- The `plain` (quick-edit list) view skips the whole computation — it never renders `--auto-size`, so the measurement was discarded for every item of every slide.

Resizing an auto-size textbox no longer calls `refreshEditSlide`. That remounted the whole editor 3 s after the resize (visible blink, focus and caret lost). The editbox re-fits from the updated item style, and previews/output invalidate their own cached size through `buildAutoSizeSignature`.

`autosize()` now removes its measuring clone in a `finally` block — it leaked one on a throw, which matters more now that it can run every frame — and marks the clone non-editable, so the browser doesn't spellcheck a fresh `contenteditable` copy up to 60×/s.

## Verification

`svelte-check`, eslint and prettier show no new findings versus `dev`; production build passes.

In a browser harness against the real `autosize.ts`, the refactor returns byte-identical sizes to `dev` (`shrinkToFit` at three text lengths, plus `growToFit`) and leaks 0 clones on a throw where `dev` leaks 1. Measured cost of one call is 0.03 ms for a short line and 0.26 ms for ~700 characters, so per-frame is comfortable and the adaptive fallback is only a safety net.

Worth a look when testing: typing in `shrinkToFit` and `growToFit` boxes, dragging the resize handles, chords mode, paste, and an IME if you have one set up.
