### PR TITLE
Give Planning Center imports distinct show icons

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -440,6 +440,7 @@
         "sound_effects": "Sound effects",
         "song": "Songs",
         "presentation": "Presentations",
+        "planning_center": "Planning Center",
         "info": "Info",
         "scripture": "Scripture",
         "events": "Events",

--- a/src/electron/contentProviders/planningCenter/request.ts
+++ b/src/electron/contentProviders/planningCenter/request.ts
@@ -599,7 +599,7 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
         console.warn(`Planning Center: Song "${songData.attributes?.title}" has sequence but no matching sections. Sequence: ${sequence.join(", ")}`)
     }
 
-    const show = getShow(songData, song, sections)
+    const show = getShow(songData, song, sections, true)
     const showId = `pcosong_${songData.id}`
 
     return {
@@ -1005,7 +1005,7 @@ function getDateTitle(dateString: string) {
 
 const itemStyle = "left:50px;top:120px;width:1820px;height:840px;"
 
-function getShow(SONG_DATA: any, SONG: any, SECTIONS: any[]) {
+function getShow(SONG_DATA: any, SONG: any, SECTIONS: any[], isSong: boolean = false) {
     const slides: { [key: string]: Slide } = {}
     const layoutSlides: SlideData[] = []
     SECTIONS.forEach((section) => {
@@ -1061,7 +1061,7 @@ function getShow(SONG_DATA: any, SONG: any, SECTIONS: any[]) {
 
     const show: Show = {
         name: title,
-        category: "planning_center",
+        category: isSong ? "song" : "planning_center",
         timestamps: { created: new Date(SONG.created_at).getTime() || Date.now(), modified: new Date(SONG.updated_at).getTime() || null, used: null },
         meta: metadata,
         settings: {

--- a/src/electron/data/defaults.ts
+++ b/src/electron/data/defaults.ts
@@ -91,7 +91,8 @@ export const defaultSettings: { [key in SaveListSettings]: any } = {
 export const defaultSyncedSettings: { [key in SaveListSyncedSettings]: any } = {
     categories: {
         song: { name: "category.song", icon: "song", default: true },
-        presentation: { name: "category.presentation", icon: "presentation", default: true }
+        presentation: { name: "category.presentation", icon: "presentation", default: true },
+        planning_center: { name: "category.planning_center", icon: "conversation", default: true }
     },
     drawSettings: {},
     overlayCategories: {


### PR DESCRIPTION
Real PCO songs and generic PCO plan items (announcements, etc.) both imported as blank-category shows, rendering as "noIcon". Songs now use the existing "song" category/icon, and generic items get a new "planning_center" category with its own icon, so the two are visually distinguishable in the project list.