### PR TITLE
Outputted slide no longer lingers on top of the media replacing it

### DIFF
--- a/src/frontend/components/helpers/output.ts
+++ b/src/frontend/components/helpers/output.ts
@@ -1616,7 +1616,7 @@ export function getStyleTemplate(outSlide: OutSlide | null, currentStyle: Styles
 }
 
 export function slideHasAutoSizeItem(slide: Slide | Template) {
-    return slide?.items?.find((a) => a.auto)
+    return slide?.items?.some((a) => (a.textFit || "none") !== "none" || a.auto)
 }
 
 export function setTemplateStyle(outSlide: OutSlide | null, currentStyle: Styles, items: Item[] | undefined, outputId: string, slideDynamicValues?: { [key: string]: any }) {

--- a/src/frontend/components/output/Output.svelte
+++ b/src/frontend/components/output/Output.svelte
@@ -305,11 +305,10 @@
     $: templateBackgroundData = { path: templateBackground, loop: true, ...($media[templateBackground] || {}) }
     $: backgroundData = templateBackground ? templateBackgroundData : background
 
-    // "foreground" media clears the slide as it is outputted, but it is drawn below the slide,
-    // so a fading out slide would be visible on top of the media - remove the transition in that case
+    // remove slide transition when replaced by "foreground" media (drawn below slide)
     const noTransition: Transition = { type: "none", duration: 0, easing: "" }
     $: textTransition = !slide && backgroundData?.ignoreLayer ? noTransition : transitions.text
-    // a PDF/PPT is cleared when a background is outputted, and it is drawn above the background as well
+    // remove PDF/PPT transition when background is outputted
     $: slideMediaTransition = !slide && backgroundData ? noTransition : transitions.media
 
     $: overlaysActive = !!(layers.includes("overlays") && clonedOverlays)

--- a/src/frontend/components/output/Output.svelte
+++ b/src/frontend/components/output/Output.svelte
@@ -5,7 +5,7 @@
     import { uid } from "uid"
     import type { OutData } from "../../../types/Output"
     import type { Styles } from "../../../types/Settings"
-    import type { AnimationData, Item, LayoutRef, OutBackground, OutSlide, Slide, SlideData, Template, Overlays as TOverlays } from "../../../types/Show"
+    import type { AnimationData, Item, LayoutRef, OutBackground, OutSlide, Slide, SlideData, Template, Transition, Overlays as TOverlays } from "../../../types/Show"
     import { allOutputs, colorbars, currentWindow, drawSettings, drawTool, effects, media, outputs, overlays, showsCache, styles, templates, transitionData } from "../../stores"
     import { wait } from "../../utils/common"
     import { custom } from "../../utils/transitions"
@@ -305,6 +305,13 @@
     $: templateBackgroundData = { path: templateBackground, loop: true, ...($media[templateBackground] || {}) }
     $: backgroundData = templateBackground ? templateBackgroundData : background
 
+    // "foreground" media clears the slide as it is outputted, but it is drawn below the slide,
+    // so a fading out slide would be visible on top of the media - remove the transition in that case
+    const noTransition: Transition = { type: "none", duration: 0, easing: "" }
+    $: textTransition = !slide && backgroundData?.ignoreLayer ? noTransition : transitions.text
+    // a PDF/PPT is cleared when a background is outputted, and it is drawn above the background as well
+    $: slideMediaTransition = !slide && backgroundData ? noTransition : transitions.media
+
     $: overlaysActive = !!(layers.includes("overlays") && clonedOverlays)
 
     // draw zoom
@@ -365,7 +372,7 @@
     <!-- slide -->
     {#if actualSlide?.type === "pdf" && layers.includes("background")}
         <span style="zoom: {1 / ratio};">
-            <PdfOutput slide={actualSlide} {currentStyle} transition={transitions.media} />
+            <PdfOutput slide={actualSlide} {currentStyle} transition={slideMediaTransition} />
         </span>
     {:else if actualSlide?.type === "ppt" && layers.includes("slide")}
         <span style="zoom: {1 / ratio};">
@@ -374,10 +381,10 @@
             {/if}
         </span>
     {:else if actualSlide && actualSlide?.type !== "pdf"}
-        <SlideContent {outputId} outSlide={actualSlide} isClearing={isSlideClearing} slideData={actualSlideData} currentSlide={actualCurrentSlide} {currentStyle} {animationData} currentLineId={actualCurrentLineId} {lines} {ratio} {mirror} {preview} transition={transitions.text} transitionEnabled={!mirror || preview} {styleIdOverride} />
+        <SlideContent {outputId} outSlide={actualSlide} isClearing={isSlideClearing} slideData={actualSlideData} currentSlide={actualCurrentSlide} {currentStyle} {animationData} currentLineId={actualCurrentLineId} {lines} {ratio} {mirror} {preview} transition={textTransition} transitionEnabled={!mirror || preview} {styleIdOverride} />
 
         <!-- metadata -->
-        <Overlay overlay={{ items: currentMetadataItems }} isClearing={isMetadataClearing || isSlideClearing} {outputId} transition={transitions.text} />
+        <Overlay overlay={{ items: currentMetadataItems }} isClearing={isMetadataClearing || isSlideClearing} {outputId} transition={textTransition} />
     {/if}
 
     {#if layers.includes("overlays")}
@@ -397,7 +404,7 @@
         {#if mirror}
             <p class="attributionString">{actualSlide.attributionString.slice(0, 135)}</p>
         {:else}
-            <p class="attributionString" transition:custom={transitions.text}>{actualSlide.attributionString.slice(0, 135)}</p>
+            <p class="attributionString" transition:custom={textTransition}>{actualSlide.attributionString.slice(0, 135)}</p>
         {/if}
     {/if}
 

--- a/src/frontend/components/output/layers/Overlay.svelte
+++ b/src/frontend/components/output/layers/Overlay.svelte
@@ -57,7 +57,7 @@
 {#key show}
     {#each currentItems as item}
         {#if show && shouldItemBeShown(item, [], showItemRef, conditionsUpdater)}
-            <SlideItemTransition {transitionEnabled} globalTransition={transition} {item} let:customItem>
+            <SlideItemTransition {transitionEnabled} {isClearing} globalTransition={transition} {item} let:customItem>
                 <Textbox item={customItem} ref={{ type: "overlay", id }} {mirror} {preview} {outputId} updateDynamicValues={!isClearing} />
             </SlideItemTransition>
         {/if}

--- a/src/frontend/components/output/layers/SlideContent.svelte
+++ b/src/frontend/components/output/layers/SlideContent.svelte
@@ -177,8 +177,7 @@
         return item?.id ? String(item.id) : `idx-${index}`
     }
 
-    // the outgoing items hold for the auto size delay while the incoming content calculates its font size,
-    // only the incoming content knows if that is needed (e.g. going from scripture to a regular text slide)
+    // outgoing items hold for auto size delay while incoming content calculates font size
     $: incomingNeedsAutoSize = slideNeedsAutoSize(currentSlide, outSlide, currentStyle)
     function slideNeedsAutoSize(slide: any, out: OutSlide, style: any) {
         if (slide?.items?.some((a: Item) => a.auto && !a.autoFontSize)) return true
@@ -186,7 +185,7 @@
         let customTemplate = getStyleTemplate(out, style)
         if (!Object.keys(customTemplate).length && out?.id === "temp") customTemplate = $templates[$scriptureSettings.template] || {}
 
-        return Object.keys(customTemplate).length ? !!slideHasAutoSizeItem(customTemplate) : false
+        return slideHasAutoSizeItem(customTemplate)
     }
 
     let isClearingToEmpty = false

--- a/src/frontend/components/output/layers/SlideContent.svelte
+++ b/src/frontend/components/output/layers/SlideContent.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
     import { onDestroy, onMount } from "svelte"
     import type { Item, OutSlide, SlideData, TimelineAction, Transition } from "../../../../types/Show"
-    import { showsCache, slideTimelineSpeedMultiplier } from "../../../stores"
+    import { scriptureSettings, showsCache, slideTimelineSpeedMultiplier, templates } from "../../../stores"
     import { waitUntilValueIsDefined } from "../../../utils/common"
     import { shouldItemBeShown } from "../../edit/scripts/itemHelpers"
     import { clone } from "../../helpers/array"
     import { loadCustomFonts } from "../../helpers/fonts"
+    import { getStyleTemplate, slideHasAutoSizeItem } from "../../helpers/output"
     import Textbox from "../../slide/Textbox.svelte"
     import { SlideTimeline } from "../../timeline/SlideTimeline"
     import SlideItemTransition from "../transitions/SlideItemTransition.svelte"
@@ -174,6 +175,18 @@
     // create a stable identifier for precompute + visible textbox coordination
     function createAutoSizeKey(item: Item, index: number) {
         return item?.id ? String(item.id) : `idx-${index}`
+    }
+
+    // the outgoing items hold for the auto size delay while the incoming content calculates its font size,
+    // only the incoming content knows if that is needed (e.g. going from scripture to a regular text slide)
+    $: incomingNeedsAutoSize = slideNeedsAutoSize(currentSlide, outSlide, currentStyle)
+    function slideNeedsAutoSize(slide: any, out: OutSlide, style: any) {
+        if (slide?.items?.some((a: Item) => a.auto && !a.autoFontSize)) return true
+
+        let customTemplate = getStyleTemplate(out, style)
+        if (!Object.keys(customTemplate).length && out?.id === "temp") customTemplate = $templates[$scriptureSettings.template] || {}
+
+        return Object.keys(customTemplate).length ? !!slideHasAutoSizeItem(customTemplate) : false
     }
 
     let isClearingToEmpty = false
@@ -436,7 +449,7 @@
             <!-- Transitioning item: render with animation wrapper inside {#key} -->
             {#key show}
                 {#if show}
-                    <SlideItemTransition {preview} {transitionEnabled} {transitioningBetween} globalTransition={transition} currentSlide={current.currentSlide} {item} outSlide={current.outSlide} lines={current.lines} currentStyle={current.currentStyle} let:customSlide let:customItem let:customLines let:customOut let:transition>
+                    <SlideItemTransition {preview} {transitionEnabled} {transitioningBetween} {isClearing} {incomingNeedsAutoSize} globalTransition={transition} currentSlide={current.currentSlide} {item} outSlide={current.outSlide} lines={current.lines} currentStyle={current.currentStyle} let:customSlide let:customItem let:customLines let:customOut let:transition>
                         <Textbox
                             backdropFilter={current.slideData?.["backdrop-filter"] || ""}
                             chords={customItem.chords?.enabled}

--- a/src/frontend/components/output/transitions/SlideItemTransition.svelte
+++ b/src/frontend/components/output/transitions/SlideItemTransition.svelte
@@ -10,6 +10,10 @@
     export let globalTransition: Transition
     export let transitionEnabled = false
     export let transitioningBetween = false
+    export let isClearing = false
+    // the auto size delay holds the outgoing item while the incoming content calculates its font size,
+    // so it is only needed when the incoming content actually needs it (this only knows the outgoing item)
+    export let incomingNeedsAutoSize = true
     export let preview = false
     export let item: Item
     export let currentSlide: any = {}
@@ -20,6 +24,27 @@
     let currentlyTransitioning: { [key: string]: any } = {}
 
     $: if (item !== undefined || lines) startTransition()
+
+    // the out transition is set when the item is created, but when clearing there is no new content coming in:
+    // the auto size delay would just keep the item visible on top of any media taking over the output,
+    // and "globalTransition" might have been updated since (e.g. removed when "foreground" media is outputted)
+    $: clearingOutTransition = getClearingOutTransition(globalTransition, item)
+    function getClearingOutTransition(global: Transition, currentItem: Item): Transition {
+        const itemTransition = currentItem?.actions?.transition ? clone(currentItem.actions.transition) : null
+        const transition = itemTransition || global || ({} as Transition)
+        const out = clone(transition.out || transition) as Transition
+
+        if (out.type === "none") out.duration = 0
+
+        // keep a custom "hide" delay, but not the auto size delay
+        const hideDuration = $currentWindow === "output" || preview ? currentItem?.actions?.hideTimer || 0 : 0
+        out.delay = hideDuration ? hideDuration * 1000 : 0
+
+        // delay won't work if no transition
+        if (out.delay && (out.type === "none" || !out.duration)) return { ...out, type: "fade", duration: 1 }
+
+        return out
+    }
 
     // WIP item wait out time will not clear other items without wait time if between transition
     // WIP slide direction from top to bottom is a bit buggy
@@ -51,6 +76,7 @@
 
         let inDelay = 0
         let outDelay = 0
+        let autoSizeDelay = 0
 
         // ITEM IN/OUT DELAY
         let showDuration = $currentWindow === "output" || preview ? item?.actions?.showTimer || 0 : 0
@@ -70,7 +96,8 @@
             const itemNeedsAutoSize = item.auto && !item.autoFontSize
 
             if (templateNeedsAutoSize || itemNeedsAutoSize) {
-                outDelay = 500
+                autoSizeDelay = 500
+                outDelay = autoSizeDelay
                 if (!inDelay) inDelay = outDelay * 0.98
             }
         }
@@ -104,11 +131,17 @@
             currentSlide: clone(currentSlide),
             inTransition,
             outTransition,
-            transitionBetween
+            transitionBetween,
+            autoSizeDelay
         }
 
         currentlyTransitioning[stateId] = state
         currentlyTransitioning = currentlyTransitioning
+    }
+
+    function withoutAutoSizeDelay(out: Transition, autoSizeDelay: number): Transition {
+        if (!autoSizeDelay) return out
+        return { ...out, delay: Math.max(0, (out.delay || 0) - autoSizeDelay) }
     }
 
     // only update if new ID! Previous is removed, but output should not update until a new value is set
@@ -122,7 +155,7 @@
 </script>
 
 {#each Object.values(currentOut) as transitioning}
-    <OutputTransition inTransition={transitionEnabled ? transitioning.inTransition : null} outTransition={transitionEnabled ? (transitioningBetween ? transitioning.transitionBetween : transitioning.outTransition) : null}>
+    <OutputTransition inTransition={transitionEnabled ? transitioning.inTransition : null} outTransition={transitionEnabled ? (isClearing ? clearingOutTransition : withoutAutoSizeDelay(transitioningBetween ? transitioning.transitionBetween : transitioning.outTransition, incomingNeedsAutoSize ? 0 : transitioning.autoSizeDelay)) : null}>
         <slot customItem={transitioning.item} customLines={transitioning.lines} customOut={transitioning.outSlide} customSlide={transitioning.currentSlide} transition={transitionEnabled ? transitioning.inTransition : null} />
     </OutputTransition>
 {/each}

--- a/src/frontend/components/output/transitions/SlideItemTransition.svelte
+++ b/src/frontend/components/output/transitions/SlideItemTransition.svelte
@@ -11,8 +11,7 @@
     export let transitionEnabled = false
     export let transitioningBetween = false
     export let isClearing = false
-    // the auto size delay holds the outgoing item while the incoming content calculates its font size,
-    // so it is only needed when the incoming content actually needs it (this only knows the outgoing item)
+    // outgoing items hold for auto size delay while incoming content calculates font size
     export let incomingNeedsAutoSize = true
     export let preview = false
     export let item: Item
@@ -25,18 +24,15 @@
 
     $: if (item !== undefined || lines) startTransition()
 
-    // the out transition is set when the item is created, but when clearing there is no new content coming in:
-    // the auto size delay would just keep the item visible on top of any media taking over the output,
-    // and "globalTransition" might have been updated since (e.g. removed when "foreground" media is outputted)
+    // update out transition if cleared without incoming content or transition changed
     $: clearingOutTransition = getClearingOutTransition(globalTransition, item)
     function getClearingOutTransition(global: Transition, currentItem: Item): Transition {
-        const itemTransition = currentItem?.actions?.transition ? clone(currentItem.actions.transition) : null
-        const transition = itemTransition || global || ({} as Transition)
+        const transition = currentItem?.actions?.transition || global || ({} as Transition)
         const out = clone(transition.out || transition) as Transition
 
         if (out.type === "none") out.duration = 0
 
-        // keep a custom "hide" delay, but not the auto size delay
+        // keep custom "hide" delay, without auto size delay
         const hideDuration = $currentWindow === "output" || preview ? currentItem?.actions?.hideTimer || 0 : 0
         out.delay = hideDuration ? hideDuration * 1000 : 0
 
@@ -92,7 +88,7 @@
             if (!Object.keys(customTemplate).length && outSlide?.id === "temp") customTemplate = $templates[$scriptureSettings.template] || {}
 
             // only keep the legacy autosize delay when nothing has pre-populated a font size yet
-            const templateNeedsAutoSize = Object.keys(customTemplate).length ? slideHasAutoSizeItem(customTemplate) : false
+            const templateNeedsAutoSize = slideHasAutoSizeItem(customTemplate)
             const itemNeedsAutoSize = item.auto && !item.autoFontSize
 
             if (templateNeedsAutoSize || itemNeedsAutoSize) {
@@ -139,9 +135,12 @@
         currentlyTransitioning = currentlyTransitioning
     }
 
-    function withoutAutoSizeDelay(out: Transition, autoSizeDelay: number): Transition {
-        if (!autoSizeDelay) return out
-        return { ...out, delay: Math.max(0, (out.delay || 0) - autoSizeDelay) }
+    function getOutTransition(transitioning: any, incomingNeedsAutoSize: boolean, transitioningBetween: boolean): Transition {
+        const transition = transitioningBetween ? transitioning.transitionBetween : transitioning.outTransition
+        if (!incomingNeedsAutoSize && transitioning.autoSizeDelay) {
+            return { ...transition, delay: Math.max(0, (transition.delay || 0) - transitioning.autoSizeDelay) }
+        }
+        return transition
     }
 
     // only update if new ID! Previous is removed, but output should not update until a new value is set
@@ -155,7 +154,8 @@
 </script>
 
 {#each Object.values(currentOut) as transitioning}
-    <OutputTransition inTransition={transitionEnabled ? transitioning.inTransition : null} outTransition={transitionEnabled ? (isClearing ? clearingOutTransition : withoutAutoSizeDelay(transitioningBetween ? transitioning.transitionBetween : transitioning.outTransition, incomingNeedsAutoSize ? 0 : transitioning.autoSizeDelay)) : null}>
+    {@const outTransition = !transitionEnabled ? null : isClearing ? clearingOutTransition : getOutTransition(transitioning, incomingNeedsAutoSize, transitioningBetween)}
+    <OutputTransition inTransition={transitionEnabled ? transitioning.inTransition : null} {outTransition}>
         <slot customItem={transitioning.item} customLines={transitioning.lines} customOut={transitioning.outSlide} customSlide={transitioning.currentSlide} transition={transitionEnabled ? transitioning.inTransition : null} />
     </OutputTransition>
 {/each}


### PR DESCRIPTION
### The problem

Media outputted as **foreground** clears the slide — but foreground media is drawn on the *background* layer, below the slide. So the outgoing slide stays visible **on top of the media** while it fades out. It reads as a glitch: text sitting over an image for a moment before disappearing.

It is worst with scripture, where the text holds fully opaque for 500ms before it even starts fading — and going from scripture to a regular text slide, both slides' text overlap for roughly 750ms.

A PDF/PPT has the same problem in reverse: outputting a background clears the slide, and the PDF is drawn above the background, so it fades out on top of the incoming media for 800ms.

### Why it happened

Three separate causes, all in the same place:

1. **The out transition is snapshotted** when an item is created (`SlideItemTransition`), so a transition updated since never reaches it.
2. **The auto size delay was set from the outgoing item.** It exists to hold the old content while the *incoming* content calculates its font size — but it was decided by the item leaving. Scripture templates use auto size text, so leaving scripture always triggered the 500ms hold, even when clearing to nothing, where there is no incoming content to wait for.
3. Nothing removed the out transition when the slide is being replaced rather than changed.

### The fix

- Remove the slide out transition when foreground media (`ignoreLayer`) or a background is taking over — the content it is replacing is already covering it.
- Compute the out transition live when clearing, instead of using the snapshot.
- Move the auto size decision to the incoming content (`SlideContent` knows both sides, `SlideItemTransition` only sees the outgoing item).

Direction by direction:

| | before | after |
|---|---|---|
| scripture → text slide | ~750ms of overlapping text | swaps cleanly |
| text slide → scripture | hold applied | hold applied (incoming needs it) |
| scripture → scripture | hold applied | unchanged |
| clear slide (F2) on scripture | 500ms hold, then fade | clears immediately |

A custom per-item **hide** delay (`hideTimer`) is preserved in every case — only the auto size delay is dropped.

### Testing

`svelte-check`, eslint and prettier all match the `dev` baseline exactly.

Worth checking visually: text slide → scripture and scripture → scripture, where the auto size hold still applies; and any items using a custom hide delay.
