### PR TITLE
Default media type: choose what "Default" means for all media

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1388,6 +1388,7 @@
         "auto_output": "Activate output screen on startup",
         "hide_cursor_in_output": "Hide cursor in output",
         "clear_media_when_finished": "Clear media when finished",
+        "default_media_type": "Default media type",
         "disable_presenter_controller_keys": "Disable presenter controller keys",
         "default_project_name": "Default project name",
         "audio_fade_duration": "Audio fade duration",

--- a/src/frontend/components/actions/apiHelper.ts
+++ b/src/frontend/components/actions/apiHelper.ts
@@ -16,7 +16,7 @@ import { ondrop } from "../helpers/drop"
 import { dropActions } from "../helpers/dropActions"
 import { history } from "../helpers/history"
 import { setDrawerTabData } from "../helpers/historyHelpers"
-import { encodeFilePath, getExtension, getFileName, getMediaLayerType, getMediaStyle, getMediaType, removeExtension } from "../helpers/media"
+import { encodeFilePath, getExtension, getFileName, getMediaStyle, getMediaType, getOutputMediaLayerType, removeExtension } from "../helpers/media"
 import { getActiveOutputs, getAllEnabledOutputs, getCurrentStyle, getFirstActiveOutput, isOutCleared, setOutput } from "../helpers/output"
 import { setRandomValue } from "../helpers/randomValue"
 import { loadShows, setShow } from "../helpers/setShow"
@@ -159,11 +159,11 @@ export async function startProjectItemByName(name: string) {
         const mediaData = get(media)[item.id] || {}
         const mediaStyle = getMediaStyle(mediaData, outputStyle)
 
-        const videoType = getMediaLayerType(item.id, mediaStyle)
+        const videoType = getOutputMediaLayerType(item.id, mediaStyle)
         const shouldLoop = videoType === "background" ? item.loop || true : false
         const shouldBeMuted = videoType === "background" ? item.muted || true : false
 
-        let out = { path: item.id, muted: shouldBeMuted, loop: shouldLoop, startAt: 0, type: item.type, ...mediaStyle }
+        let out = { path: item.id, muted: shouldBeMuted, loop: shouldLoop, startAt: 0, type: item.type, ...mediaStyle, ignoreLayer: videoType === "foreground" }
 
         // clear slide
         if (videoType === "foreground" || (videoType !== "background" && (item.type === "image" || !shouldLoop))) clearSlide()

--- a/src/frontend/components/context/menuClick.ts
+++ b/src/frontend/components/context/menuClick.ts
@@ -103,7 +103,7 @@ import { getItemText, getSelectionRange } from "../edit/scripts/textStyle"
 import { clone, removeDuplicates, sortObjectNumbers } from "../helpers/array"
 import { copy, cut, deleteAction, duplicate, paste, selectAll } from "../helpers/clipboard"
 import { history, redo, undo } from "../helpers/history"
-import { getExtension, getFileName, getMediaLayerType, getMediaStyle, getMediaType, removeExtension, splitPath } from "../helpers/media"
+import { getExtension, getFileName, getMediaStyle, getMediaType, getOutputMediaLayerType, removeExtension, splitPath } from "../helpers/media"
 import { defaultOutput, getCurrentStyle, getFirstActiveOutput, setOutput, toggleOutput, toggleOutputs } from "../helpers/output"
 import { select } from "../helpers/select"
 import { bindSlidesToOutput, checkName, formatToFileName, getLayoutRef, openShow, removeTemplatesFromShow, updateShowsList } from "../helpers/show"
@@ -1596,14 +1596,14 @@ const clickActions = {
         const outputStyle = get(styles)[currentOutput?.style || ""]
         const mediaStyle: MediaStyle = getMediaStyle(get(media)[path], outputStyle)
 
-        const videoType = getMediaLayerType(path, mediaStyle)
+        const videoType = getOutputMediaLayerType(path, mediaStyle)
 
         // clear slide text
         // if (get(projects)[get(activeProject) || ""]?.shows?.find((a) => a.id === path)) clearSlide()
         if (videoType === "foreground") clearSlide()
 
         const type = getMediaType(getExtension(path))
-        setOutput("background", { path, ...mediaStyle, type, loop: false, muted: false })
+        setOutput("background", { path, ...mediaStyle, type, loop: false, muted: false, ignoreLayer: videoType === "foreground" })
     },
     play_no_audio: (obj: ObjData) => {
         if (get(outLocked)) return
@@ -1625,12 +1625,15 @@ const clickActions = {
         const path = obj.sel?.data[0]?.path || obj.sel?.data[0]?.id
         if (!path) return
 
-        const videoType = getMediaLayerType(path, get(media)[path])
+        const videoType = getOutputMediaLayerType(path, get(media)[path])
         const loop = videoType === "foreground" ? false : true
         const muted = videoType === "foreground" ? false : true
 
+        // clear slide text
+        if (videoType === "foreground") clearSlide()
+
         const type = getMediaType(getExtension(path))
-        setOutput("background", { path, type, loop, muted })
+        setOutput("background", { path, type, loop, muted, ignoreLayer: videoType === "foreground" })
     },
     favourite: (obj: ObjData) => {
         if (!obj.sel) return

--- a/src/frontend/components/drawer/info/MediaInfo.svelte
+++ b/src/frontend/components/drawer/info/MediaInfo.svelte
@@ -2,12 +2,14 @@
     import { Main } from "../../../../types/IPC/Main"
     import { requestMain, sendMain } from "../../../IPC/main"
     import { activeRecording, activeShow, cloudSyncData, drawerTabsData, special } from "../../../stores"
+    import { translateText } from "../../../utils/language"
     import { videoExtensions } from "../../../values/extensions"
     import { formatBytes } from "../../helpers/bytes"
     import { getExtension, getFileName, getMediaInfo, removeExtension } from "../../helpers/media"
     import T from "../../helpers/T.svelte"
     import InputRow from "../../input/InputRow.svelte"
     import MaterialButton from "../../inputs/MaterialButton.svelte"
+    import MaterialDropdown from "../../inputs/MaterialDropdown.svelte"
     import MaterialToggleSwitch from "../../inputs/MaterialToggleSwitch.svelte"
     import Center from "../../system/Center.svelte"
     import Clock from "../../system/Clock.svelte"
@@ -65,6 +67,12 @@
         })
     }
 
+    const mediaTypeOptions = [
+        { value: "", label: translateText("example.default") },
+        { value: "background", label: translateText("preview.background"), icon: "type_background" },
+        { value: "foreground", label: translateText("preview.foreground"), icon: "type_foreground" }
+    ]
+
     // bundle media files
     function bundleMediaFiles() {
         sendMain(Main.BUNDLE_MEDIA_FILES, { openFolder: true })
@@ -79,6 +87,8 @@
     <div class="scroll">
         {#if optionsOpen}
             <main style="overflow-x: hidden;padding: 10px;">
+                <MaterialDropdown label="settings.default_media_type" options={mediaTypeOptions} value={$special.defaultMediaType || ""} defaultValue="" on:change={(e) => updateSpecial(e.detail, "defaultMediaType")} />
+
                 <MaterialToggleSwitch label="settings.clear_media_when_finished" checked={$special.clearMediaOnFinish ?? true} defaultValue={true} on:change={(e) => updateSpecial(e.detail, "clearMediaOnFinish", true)} />
                 <MaterialToggleSwitch label="settings.auto_locate_missing_media_files" checked={$special.autoLocateMedia ?? true} defaultValue={true} on:change={(e) => updateSpecial(e.detail, "autoLocateMedia", true)} />
 

--- a/src/frontend/components/drawer/media/Media.svelte
+++ b/src/frontend/components/drawer/media/Media.svelte
@@ -10,7 +10,7 @@
     import T from "../../helpers/T.svelte"
     import { clone, keysToID, sortFilenames } from "../../helpers/array"
     import { splitPath } from "../../helpers/get"
-    import { countFolderMediaItems, getExtension, getFileName, getMediaLayerType, getMediaStyle, getMediaType, isMediaExtension, removeExtension } from "../../helpers/media"
+    import { countFolderMediaItems, getExtension, getFileName, getMediaStyle, getMediaType, getOutputMediaLayerType, isMediaExtension, removeExtension } from "../../helpers/media"
     import { getFirstActiveOutput, setOutput } from "../../helpers/output"
     import FloatingInputs from "../../input/FloatingInputs.svelte"
     import MaterialButton from "../../inputs/MaterialButton.svelte"
@@ -417,13 +417,13 @@
                 const outputStyle = $styles[currentOutput?.style || ""]
                 const mediaStyle = getMediaStyle($media[file.path], outputStyle)
 
-                const videoType = getMediaLayerType(file.path, mediaStyle)
+                const videoType = getOutputMediaLayerType(file.path, mediaStyle)
 
                 // clear slide text
                 if (videoType === "foreground") clearSlide()
 
                 const type = getMediaType(getExtension(file.path))
-                setOutput("background", { path: file.path, ...mediaStyle, type, loop: false, muted: false })
+                setOutput("background", { path: file.path, ...mediaStyle, type, loop: false, muted: false, ignoreLayer: videoType === "foreground" })
                 return
             }
 

--- a/src/frontend/components/drawer/media/MediaCard.svelte
+++ b/src/frontend/components/drawer/media/MediaCard.svelte
@@ -8,7 +8,7 @@
     import { translateText } from "../../../utils/language"
     import { getKey } from "../../../values/keys"
     import Icon from "../../helpers/Icon.svelte"
-    import { getMediaLayerType, getMediaStyle, getMediaType, loadThumbnail } from "../../helpers/media"
+    import { getMediaStyle, getMediaType, getOutputMediaLayerType, loadThumbnail } from "../../helpers/media"
     import { findMatchingOut, getAllActiveOutputs, getFirstActiveOutput, setOutput } from "../../helpers/output"
     import Button from "../../inputs/Button.svelte"
     import { clearBackground, clearSlide } from "../../output/clear"
@@ -125,7 +125,7 @@
             return
         }
 
-        let videoType = getMediaLayerType(path, mediaStyle)
+        let videoType = getOutputMediaLayerType(path, mediaStyle)
         let loop = contentProvider || videoType === "foreground" ? false : true
         let muted = videoType === "background" ? true : false
         if (videoType === "foreground") clearSlide()

--- a/src/frontend/components/edit/MediaTools.svelte
+++ b/src/frontend/components/edit/MediaTools.svelte
@@ -2,7 +2,7 @@
     import type { TabsObj } from "../../../types/Tabs"
     import { activeEdit, activeShow, media } from "../../stores"
     import { clone } from "../helpers/array"
-    import { getExtension, getMediaType } from "../helpers/media"
+    import { getExtension, getMediaType, getOutputMediaLayerType } from "../helpers/media"
     import { getFirstActiveOutput, setOutput } from "../helpers/output"
     import { removeStore, updateStore } from "../helpers/update"
     import FloatingInputs from "../input/FloatingInputs.svelte"
@@ -96,6 +96,10 @@
         } else {
             bg[input.id] = value
         }
+
+        // the outputted layer is set from the type when the media is outputted
+        if (input.id === "videoType") bg.ignoreLayer = getOutputMediaLayerType(mediaId, { videoType: value }) === "foreground"
+
         setOutput("background", bg)
     }
 

--- a/src/frontend/components/edit/tools/EditValues.svelte
+++ b/src/frontend/components/edit/tools/EditValues.svelte
@@ -289,6 +289,13 @@
                 return sortByName(keysToID($actions)).map((a) => ({ value: a.id, label: a.name || "" }))
             } else if (options === "outputWindows") {
                 return sortByName(keysToID($outputs).filter((a) => a.stageOutput !== $activeStage.id)).map((a) => ({ value: a.id, label: a.name || "" }))
+            } else if (options === "mediaTypes") {
+                // "background" is muted & looping, "foreground" is unmuted, not looping, and will display even when the "Background" layer is turned off
+                return [
+                    { value: "", label: $special.defaultMediaType ? `example.default (preview.${$special.defaultMediaType})` : "example.default" },
+                    { value: "background", label: "preview.background" },
+                    { value: "foreground", label: "preview.foreground" }
+                ]
             } else if (options === "captionTranslateLanguages") {
                 return item?.captions?.googlekey ? [{ value: "", label: "—" }, ...getIsoLanguages()] : captionTranslateLanguages.map((a) => ({ value: a.id, label: a.name }))
             }

--- a/src/frontend/components/edit/values/media.ts
+++ b/src/frontend/components/edit/values/media.ts
@@ -19,15 +19,8 @@ const defaultMedia = splitIntoRows([
         id: "videoType", // can be image as well
         type: "dropdown",
         value: "",
-        values: {
-            label: "clock.type",
-            defaultValue: "",
-            options: [
-                { value: "", label: "example.default" },
-                { value: "background", label: "preview.background" }, // muted, looping
-                { value: "foreground", label: "preview.foreground" } // unmuted, not looping, will display even when the "Background" layer is turned off.
-            ]
-        }
+        // "mediaTypes" is generated in EditValues, as the default option depends on the global default type
+        values: { label: "clock.type", defaultValue: "", options: "mediaTypes" }
     },
     { id: "fit", type: "dropdown", value: "", values: { label: "media.fit", defaultValue: "", options: [{ value: "", label: "themes.default" }, ...mediaFitOptions] } },
     { id: "flipped", type: "checkbox", value: false, values: { label: "media.flip_horizontally" } },

--- a/src/frontend/components/helpers/dropActions.ts
+++ b/src/frontend/components/helpers/dropActions.ts
@@ -20,7 +20,7 @@ import { addItem, DEFAULT_ITEM_STYLE } from "../edit/scripts/itemHelpers"
 import { clone, removeDuplicates } from "./array"
 import { projectDropFolders } from "./drop"
 import { history, historyAwait } from "./history"
-import { downloadOnlineMedia, getExtension, getFileName, getMediaLayerType, getMediaStyle, getMediaType, removeExtension } from "./media"
+import { downloadOnlineMedia, getExtension, getFileName, getMediaLayerType, getMediaStyle, getMediaType, getOutputMediaLayerType, removeExtension } from "./media"
 import { addToPos, getIndexes, mover } from "./mover"
 import { getLayoutRef } from "./show"
 import { getVariableNameId } from "./showActions"
@@ -644,7 +644,8 @@ const slideDrop = {
                 backgroundData = { muted: false, loop: false }
             } else {
                 const mediaStyle = getMediaStyle(get(media)[path], undefined)
-                let type = getMediaLayerType(path, mediaStyle) || (shouldBeForeground ? "foreground" : "background")
+                // "center" is dropped as a slide background, that should not use the global default type
+                let type = (center ? getMediaLayerType(path, mediaStyle) : getOutputMediaLayerType(path, mediaStyle)) || (shouldBeForeground ? "foreground" : "background")
                 if (a.contentProvider) type = "foreground"
                 if (type === "foreground") backgroundData = { muted: false, loop: false }
             }

--- a/src/frontend/components/helpers/media.ts
+++ b/src/frontend/components/helpers/media.ts
@@ -425,6 +425,14 @@ export function getMediaLayerType(path: string, style: MediaStyle | null): "" | 
     return folderData.mediaType || ""
 }
 
+// layer type for media the user is sending to output right now
+// media videoType -> media folder mediaType -> global default -> ""
+// don't use this for media that is already outputted or owned by a show, use "getMediaLayerType"
+export function getOutputMediaLayerType(path: string, style: MediaStyle | null): "" | "background" | "foreground" {
+    if (!path) return ""
+    return getMediaLayerType(path, style) || (get(special).defaultMediaType as "background" | "foreground") || ""
+}
+
 export const mediaSize = {
     big: 900, // stage & editor
     slideSize: 500, // slide + remote

--- a/src/frontend/components/helpers/output.ts
+++ b/src/frontend/components/helpers/output.ts
@@ -8,7 +8,7 @@ import type { Resolution, Styles } from "../../../types/Settings"
 import type { Item, Layout, LayoutRef, Media, OutSlide, Show, Slide, SlideData, Template, TemplateSettings, Transition } from "../../../types/Show"
 import { AudioAnalyser } from "../../audio/audioAnalyser"
 import { requestMain, sendMain } from "../../IPC/main"
-import { actions, activeFocus, activeProject, activeRename, activeShow, activeTimers, allOutputs, categories, connections, currentOutputSettings, customMessageCredits, disabledServers, effects, focusMode, lockedOverlays, media, outputDisplay, outputs, outputSlideCache, outputState, overlays, overlayTimers, projects, scriptures, scriptureSettings, serverData, showsCache, special, stageShows, styles, templates, theme, themes, transitionData, usageLog } from "../../stores"
+import { actions, activeFocus, activeProject, activeRename, activeShow, activeTimers, allOutputs, categories, connections, currentOutputSettings, customMessageCredits, disabledServers, effects, focusMode, lockedOverlays, outputDisplay, outputs, outputSlideCache, outputState, overlays, overlayTimers, projects, scriptures, scriptureSettings, serverData, showsCache, special, stageShows, styles, templates, theme, themes, transitionData, usageLog } from "../../stores"
 import { trackScriptureUsage } from "../../utils/analytics"
 import { isMainWindow, isOutputWindow, newToast } from "../../utils/common"
 import { translateText } from "../../utils/language"
@@ -23,7 +23,7 @@ import type { EditInput } from "../edit/values/boxes"
 import { VideoPlayer } from "../media/video/videoPlayer"
 import { clearBackground, clearSlide } from "../output/clear"
 import { areObjectsEqual, clone, keysToID, removeDuplicates, sortByName, sortObject } from "./array"
-import { getExtension, getFileName, getMediaLayerType, getMediaType, removeExtension } from "./media"
+import { getExtension, getFileName, getMediaType, removeExtension } from "./media"
 import { getLayoutRef } from "./show"
 import { getFewestOutputLines, getItemWithMostLines } from "./showActions"
 import { _show } from "./shows"
@@ -138,11 +138,11 @@ export function setOutput(type: string, data: any, toggle = false, outputId = ""
             if (overrideCategoryAction) resetActionTrigger = true
             else resetActionTrigger = false
 
-            // if current playing background is "foreground", clear it
+            // if current playing background is "foreground", clear it (revealing any style background)
+            // "ignoreLayer" is set when the media is outputted, don't get the type again here,
+            // as that would also clear backgrounds set by a show/style/template
             const currentBackground = get(outputs)[outs?.[0]]?.out?.background || {}
-            const mediaData = get(media)[currentBackground.path || ""] || {}
-            const mediaType = getMediaLayerType(currentBackground.path || "", mediaData)
-            if (mediaType === "foreground") clearBackground()
+            if (currentBackground.ignoreLayer) clearBackground()
         }
 
         let toggleState = false

--- a/src/frontend/components/inputs/ShowButton.svelte
+++ b/src/frontend/components/inputs/ShowButton.svelte
@@ -8,7 +8,7 @@
     import { customIconsColors } from "../../values/customIcons"
     import { history, historyAwait } from "../helpers/history"
     import Icon from "../helpers/Icon.svelte"
-    import { encodeFilePath, getExtension, getFileName, getMedia, getMediaLayerType, getMediaStyle, getMediaType, getVideoDuration, mediaSize, removeExtension } from "../helpers/media"
+    import { encodeFilePath, getExtension, getFileName, getMedia, getMediaStyle, getMediaType, getOutputMediaLayerType, getVideoDuration, mediaSize, removeExtension } from "../helpers/media"
     import { findMatchingOut, getActiveOutputs, setOutput, startFolderTimer } from "../helpers/output"
     import { loadShows } from "../helpers/setShow"
     import { checkName, getLayoutRef } from "../helpers/show"
@@ -163,14 +163,14 @@
             const mediaData = $media[id] || {}
             const mediaStyle = getMediaStyle(mediaData, outputStyle)
 
-            const videoType = getMediaLayerType(id, mediaStyle)
+            const videoType = getOutputMediaLayerType(id, mediaStyle)
             const shouldLoop = videoType === "background" ? show.loop || true : false
             const shouldBeMuted = videoType === "background" ? show.muted || true : false
 
             const located = await getMedia(id)
             if (!located) return
 
-            let out = { path: located.path, muted: shouldBeMuted, loop: shouldLoop, startAt: 0, type, ...mediaStyle }
+            let out = { path: located.path, muted: shouldBeMuted, loop: shouldLoop, startAt: 0, type, ...mediaStyle, ignoreLayer: videoType === "foreground" }
 
             // clear slide
             if (videoType === "foreground" || (videoType !== "background" && (type === "image" || !shouldLoop))) clearSlide()

--- a/src/frontend/components/output/preview/ClearButtons.svelte
+++ b/src/frontend/components/output/preview/ClearButtons.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
     import { createEventDispatcher } from "svelte"
     import { clearAudio } from "../../../audio/audioFading"
-    import { activeTimers, dictionary, isFadingOut, isTimelinePlaying, labelsDisabled, media, outLocked, outputCache, outputs, overlayTimers, playingAudio, playingMetronome, styles, timelineRecordingAction } from "../../../stores"
+    import { activeTimers, dictionary, isFadingOut, isTimelinePlaying, labelsDisabled, outLocked, outputCache, outputs, overlayTimers, playingAudio, playingMetronome, styles, timelineRecordingAction } from "../../../stores"
     import { presentationControllersKeysDisabled } from "../../../utils/shortcuts"
     import Icon from "../../helpers/Icon.svelte"
-    import { getMediaLayerType } from "../../helpers/media"
     import { getActiveOutputs, getOutputContent, isOutCleared } from "../../helpers/output"
     import T from "../../helpers/T.svelte"
     import MaterialButton from "../../inputs/MaterialButton.svelte"
@@ -71,7 +70,6 @@
     $: canDisplayStyleBG = !outputStyle.clearStyleBackgroundOnText || (!output.out?.slide && !output.out?.background)
     $: styleBackground = backgroundCleared && !$outLocked && outputStyle.backgroundImage && canDisplayStyleBG
     $: outBackground = output.out?.background || {}
-    $: backgroundData = $media[outBackground.path || ""] || {}
 
     $: isScripture = outputContent?.id === "temp"
     $: isMetronome = $playingMetronome && !Object.keys($playingAudio).length
@@ -140,7 +138,8 @@
             </div>
         {/if}
 
-        {#if getMediaLayerType(outBackground.path || "", backgroundData) !== "foreground" || !slideCleared}
+        <!-- "ignoreLayer" is set when the media is outputted, don't get the type again here -->
+        {#if !outBackground.ignoreLayer || !slideCleared}
             <div class="combinedButton">
                 <MaterialButton style="padding: 0.3em 0.6em;" disabled={$outLocked || slideCleared} title="clear.slide  [F2]" on:click={() => clear("slide")} red>
                     <!-- PDFs are visually the background layer as it is toggled by the style "Background" layer, but it behaves as a slide in the code -->

--- a/src/frontend/components/show/VideoShow.svelte
+++ b/src/frontend/components/show/VideoShow.svelte
@@ -9,7 +9,7 @@
     import { translateText } from "../../utils/language"
     import Icon from "../helpers/Icon.svelte"
     import T from "../helpers/T.svelte"
-    import { enableSubtitle, encodeFilePath, getExtension, getFileName, getMediaLayerType, removeExtension } from "../helpers/media"
+    import { enableSubtitle, encodeFilePath, getExtension, getFileName, getOutputMediaLayerType, removeExtension } from "../helpers/media"
     import { getFirstActiveOutput, setOutput } from "../helpers/output"
     import { joinTime, secondsToTime } from "../helpers/time"
     import FloatingInputs from "../input/FloatingInputs.svelte"
@@ -176,7 +176,7 @@
 
     let shouldLoop = false
     let shouldBeMuted = false
-    $: videoType = getMediaLayerType(mediaPath, mediaStyle)
+    $: videoType = getOutputMediaLayerType(mediaPath, mediaStyle)
     $: projectItem = $projects[$activeProject || ""]?.shows?.[show?.index]
     $: if (mediaPath) {
         shouldLoop = typeof projectItem?.loop === "boolean" ? projectItem.loop : videoType === "background" ? true : false

--- a/src/frontend/components/show/folder/FolderShow.svelte
+++ b/src/frontend/components/show/folder/FolderShow.svelte
@@ -12,7 +12,7 @@
     import MediaLoader from "../../drawer/media/MediaLoader.svelte"
     import { keysToID, sortByName } from "../../helpers/array"
     import Icon from "../../helpers/Icon.svelte"
-    import { getExtension, getMediaLayerType, getMediaStyle, getMediaType, getVideoDuration } from "../../helpers/media"
+    import { getExtension, getMediaStyle, getMediaType, getOutputMediaLayerType, getVideoDuration } from "../../helpers/media"
     import { findMatchingOut, getFirstActiveOutput, setOutput, startFolderTimer } from "../../helpers/output"
     import T from "../../helpers/T.svelte"
     import { joinTime, secondsToTime } from "../../helpers/time"
@@ -64,7 +64,7 @@
 
         const mediaStyle = getMediaStyle($media[file.path], currentStyle)
 
-        let videoType = getMediaLayerType(file.path, mediaStyle)
+        let videoType = getOutputMediaLayerType(file.path, mediaStyle)
         let loop = videoType === "foreground" ? false : true
         let muted = videoType === "background" ? true : false
         if (videoType === "foreground") clearSlide()

--- a/src/frontend/components/show/media/MediaPreview.svelte
+++ b/src/frontend/components/show/media/MediaPreview.svelte
@@ -5,7 +5,7 @@
     import { translateText } from "../../../utils/language"
     import Image from "../../drawer/media/Image.svelte"
     import Icon from "../../helpers/Icon.svelte"
-    import { getMedia, getMediaLayerType, getMediaStyle } from "../../helpers/media"
+    import { getMedia, getMediaStyle, getOutputMediaLayerType } from "../../helpers/media"
     import { getActiveOutputs, getCurrentStyle, setOutput } from "../../helpers/output"
     import HoverButton from "../../inputs/HoverButton.svelte"
     import { clearSlide } from "../../output/clear"
@@ -66,10 +66,10 @@
                     on:click={() => {
                         if ($outLocked) return
 
-                        const type = getMediaLayerType(mediaPath, mediaStyle)
+                        const type = getOutputMediaLayerType(mediaPath, mediaStyle)
                         if (type === "foreground" || type !== "background") clearSlide()
 
-                        setOutput("background", { path: mediaPath, ...mediaStyle })
+                        setOutput("background", { path: mediaPath, ...mediaStyle, ignoreLayer: type === "foreground" })
                     }}
                 >
                     {#if mediaStyle.fit === "blur"}

--- a/src/frontend/utils/shortcuts.ts
+++ b/src/frontend/utils/shortcuts.ts
@@ -11,7 +11,7 @@ import { addItem } from "../components/edit/scripts/itemHelpers"
 import { keysToID, sortByName } from "../components/helpers/array"
 import { copy, cut, deleteAction, duplicate, paste, selectAll } from "../components/helpers/clipboard"
 import { history, redo, undo } from "../components/helpers/history"
-import { getExtension, getMedia, getMediaLayerType, getMediaStyle, getMediaType } from "../components/helpers/media"
+import { getExtension, getMedia, getMediaStyle, getMediaType, getOutputMediaLayerType } from "../components/helpers/media"
 import { getFirstActiveOutput, refreshOut, setOutput, startFolderTimer, toggleOutputs } from "../components/helpers/output"
 import { OutputHelper } from "../components/helpers/OutputHelper"
 import { VideoPlayer } from "../components/media/video/videoPlayer"
@@ -506,7 +506,7 @@ export async function togglePlayingMedia(e: Event | null = null, back = false, a
         const mediaData = get(media)[item.id] || {}
         const mediaStyle = getMediaStyle(mediaData, outputStyle)
 
-        const videoType = getMediaLayerType(item.id, mediaStyle)
+        const videoType = getOutputMediaLayerType(item.id, mediaStyle)
         const projectItem = item.index !== undefined ? get(projects)[get(activeProject) || ""]?.shows?.[item.index] : null
         const shouldLoop = typeof projectItem?.loop === "boolean" ? projectItem.loop : videoType === "background" ? true : false
         const shouldBeMuted = typeof projectItem?.muted === "boolean" ? projectItem.muted : videoType === "background" ? true : false
@@ -517,7 +517,7 @@ export async function togglePlayingMedia(e: Event | null = null, back = false, a
         const located = await getMedia(item.id)
         if (!located) return
 
-        setOutput("background", { type, path: located.path, muted: shouldBeMuted, loop: shouldLoop, ...mediaStyle })
+        setOutput("background", { type, path: located.path, muted: shouldBeMuted, loop: shouldLoop, ...mediaStyle, ignoreLayer: videoType === "foreground" })
     } else if (type === "audio") {
         AudioPlayer.start(item.id, { name: (item as any).name || "" }, { pauseIfPlaying: true })
     } else if (type === "folder") {
@@ -548,7 +548,8 @@ export async function playFolder(path: string, back = false) {
     const outputStyle = get(styles)[currentOutput?.style || ""]
     const mediaStyle = getMediaStyle(get(media)[newMedia.path], outputStyle)
 
-    setOutput("background", { type: newMedia.type, path: newMedia.path, muted: false, loop: false, ...mediaStyle, folderPath: path })
+    const videoType = getOutputMediaLayerType(newMedia.path, mediaStyle)
+    setOutput("background", { type: newMedia.type, path: newMedia.path, muted: false, loop: false, ...mediaStyle, folderPath: path, ignoreLayer: videoType === "foreground" })
 
     startFolderTimer(path, newMedia)
 }


### PR DESCRIPTION
### The problem

Clicking an image or video in the media tab outputs it on the **background** layer. Any slide that is out keeps rendering its text on top of it, which looks like a glitch — the workaround is to clear the slide (or clear all) and show the media again.

For a lot of workflows that is backwards. Media opened from the media tab is usually meant to *replace* what is on screen, not sit behind it. A background for a show is better set on a style, show or template.

The per-media **Type** setting (Default / Background / Foreground) already does the right thing — but there was no way to change what *Default* means, so it had to be set on every single media file.

### The fix

A **Default media type** option in the media options panel:

<!-- screenshot of the media options panel -->

Type now resolves as:

```
media videoType  ->  media folder mediaType  ->  global default  ->  ""
```

Per-file and per-folder settings still win, so nothing that is set explicitly changes. The per-item dropdown reads "Default (Foreground)" when a global default is set, so the inherited value is visible where you would look for it.

The new `getOutputMediaLayerType` is only used where media is outputted **directly** — the media tab, project media, right-click play, shortcuts and the API. Media owned by a show, style or template resolves as before and is never affected, so show backgrounds keep behaving as backgrounds.

`"Background"` works as a global default too. Worth noting: `""` is genuinely ambiguous today — it behaves as *background* in some places and as *foreground* in others (`videoType === "foreground" || videoType !== "background"`). This setting is the first thing that makes it mean one consistent thing.

### Also included

Two things the setting depends on:

- **`ignoreLayer` is now set wherever media is outputted.** It decides whether media is drawn on the slide layer instead of the background layer, and it was only set at 5 of 11 call sites. Harmless while foreground was rare and opt-in — but once it is the default, the same action would put media on different layers depending on which code path ran.
- **Foreground media that is already outputted is detected from `ignoreLayer`** instead of resolving the type again. Re-resolving meant a slide going out cleared *every* background, including ones set by a show/style/template. Two knock-on fixes: a player started from the drawer now clears the slide as its code always intended (it has no `path`, so the old lookup bailed), and `right-click -> play (no filters)` now clears the slide like the other play actions.

### Testing

`svelte-check`, eslint and prettier all match the `dev` baseline.

Worth checking: advancing through a show with slide backgrounds (they must not flicker or clear), and dropping a video onto a slide as a background (still muted + looping).
