### PR TITLE
Check textFit when detecting items that need auto size

### DIFF
--- a/src/frontend/components/helpers/output.ts
+++ b/src/frontend/components/helpers/output.ts
@@ -1642,8 +1642,17 @@ export function getStyleTemplate(outSlide: OutSlide | null, currentStyle: Styles
     return template
 }
 
+function itemHasAutoSize(item: Item) {
+    return (item.textFit || "none") !== "none" || !!item.auto
+}
+
 export function slideHasAutoSizeItem(slide: Slide | Template) {
-    return slide?.items?.some((a) => (a.textFit || "none") !== "none" || a.auto)
+    return slide?.items?.some(itemHasAutoSize)
+}
+
+// the auto size text size has to be calculated if it is not stored yet
+export function itemNeedsAutoSize(item: Item) {
+    return itemHasAutoSize(item) && !item.autoFontSize
 }
 
 export function setTemplateStyle(outSlide: OutSlide | null, currentStyle: Styles, items: Item[] | undefined, outputId: string, slideDynamicValues?: { [key: string]: any }) {

--- a/src/frontend/components/output/layers/SlideContent.svelte
+++ b/src/frontend/components/output/layers/SlideContent.svelte
@@ -6,7 +6,7 @@
     import { shouldItemBeShown } from "../../edit/scripts/itemHelpers"
     import { clone } from "../../helpers/array"
     import { loadCustomFonts } from "../../helpers/fonts"
-    import { getStyleTemplate, slideHasAutoSizeItem } from "../../helpers/output"
+    import { getStyleTemplate, itemNeedsAutoSize, slideHasAutoSizeItem } from "../../helpers/output"
     import Textbox from "../../slide/Textbox.svelte"
     import { SlideTimeline } from "../../timeline/SlideTimeline"
     import SlideItemTransition from "../transitions/SlideItemTransition.svelte"
@@ -180,7 +180,7 @@
     // outgoing items hold for auto size delay while incoming content calculates font size
     $: incomingNeedsAutoSize = slideNeedsAutoSize(currentSlide, outSlide, currentStyle)
     function slideNeedsAutoSize(slide: any, out: OutSlide, style: any) {
-        if (slide?.items?.some((a: Item) => a.auto && !a.autoFontSize)) return true
+        if (slide?.items?.some(itemNeedsAutoSize)) return true
 
         let customTemplate = getStyleTemplate(out, style)
         if (!Object.keys(customTemplate).length && out?.id === "temp") customTemplate = $templates[$scriptureSettings.template] || {}

--- a/src/frontend/components/output/transitions/SlideItemTransition.svelte
+++ b/src/frontend/components/output/transitions/SlideItemTransition.svelte
@@ -3,7 +3,7 @@
     import type { Item, Transition } from "../../../../types/Show"
     import { currentWindow, scriptureSettings, templates } from "../../../stores"
     import { clone } from "../../helpers/array"
-    import { getStyleTemplate, slideHasAutoSizeItem } from "../../helpers/output"
+    import { getStyleTemplate, itemNeedsAutoSize, slideHasAutoSizeItem } from "../../helpers/output"
     import OutputTransition from "./OutputTransition.svelte"
     // import { onMount } from "svelte"
 
@@ -89,9 +89,8 @@
 
             // only keep the legacy autosize delay when nothing has pre-populated a font size yet
             const templateNeedsAutoSize = slideHasAutoSizeItem(customTemplate)
-            const itemNeedsAutoSize = item.auto && !item.autoFontSize
 
-            if (templateNeedsAutoSize || itemNeedsAutoSize) {
+            if (templateNeedsAutoSize || itemNeedsAutoSize(item)) {
                 autoSizeDelay = 500
                 outDelay = autoSizeDelay
                 if (!inDelay) inDelay = outDelay * 0.98


### PR DESCRIPTION
Follow-up to #3656.

`slideHasAutoSizeItem` was updated to understand `textFit`:

```js
return slide?.items?.some((a) => (a.textFit || "none") !== "none" || a.auto)
```

The two per-item checks sitting next to it were not, and still test the deprecated `auto` only:

- `SlideContent.svelte:183` — `a.auto && !a.autoFontSize`
- `SlideItemTransition.svelte:92` — `item.auto && !item.autoFontSize`

So the template half of "does this need auto size?" knows about `textFit` and the item half does not.

### Why that matters

An item can have `textFit` without `auto`, and several paths create exactly that:

- built in templates — `createData.ts:843` etc. set `textFit: "shrinkToFit"` alone
- PowerPoint import — `PowerPointHelper.ts:854` sets `item.textFit = "shrinkToFit"`
- scripture slides — `scripture.ts:1336` copies `textFit` from the template

And `Textbox` already treats `textFit` as the primary key, falling back to `auto`:

```js
const textFit = item?.textFit || (item?.auto ? (isTextItem ? "shrinkToFit" : "growToFit") : "none")
```

So such an item *does* auto size when rendered, but reported that it did not need auto size. The outgoing items then stopped waiting for it to calculate its font size — which is the blink #3656 removed, reached through a narrower path.

`setTemplateStyle` backfills `item.auto` when a **style template** defines `textFit`, so items styled through the active output style were already covered. The gap is items whose `textFit` comes from the slide itself.

### Change

One shared definition instead of three drifting ones:

```ts
function itemHasAutoSize(item: Item) {
    return (item.textFit || "none") !== "none" || !!item.auto
}

export function slideHasAutoSizeItem(slide: Slide | Template) {
    return slide?.items?.some(itemHasAutoSize)
}

// the auto size text size has to be calculated if it is not stored yet
export function itemNeedsAutoSize(item: Item) {
    return itemHasAutoSize(item) && !item.autoFontSize
}
```

`slideHasAutoSizeItem` behaves exactly as it does now; the two call sites move onto `itemNeedsAutoSize`.

`svelte-check`, eslint and prettier all match the `dev` baseline.
