### PR TITLE
Add holychords.pro paste support

### DIFF
--- a/src/frontend/converters/holychords.ts
+++ b/src/frontend/converters/holychords.ts
@@ -1,0 +1,141 @@
+// Detects holychords.pro pastes and rewrites them into the plain-text format convertText() (txt.ts) already understands.
+
+const URL_RE = /https?:\/\/(?:www\.)?holychords\.pro\/\d+\/?/i
+
+const LABELS: { re: RegExp; group: string }[] = [
+    { re: /^(?:\d+\s*)?куплет(?:\s*\d+)?\s*:?\s*$/, group: "Verse" },
+    { re: /^(?:\d+\s*)?(?:інтро|вступ)(?:\s*\d+)?\s*:?\s*$/, group: "Intro" },
+    { re: /^(?:\d+\s*)?(?:приспів|припев|хор)(?:\s*\d+)?\s*:?\s*$/, group: "Chorus" },
+    { re: /^(?:\d+\s*)?(?:бридж|міст)(?:\s*\d+)?\s*:?\s*$/, group: "Bridge" }
+]
+
+function matchLabel(line: string): string | null {
+    const trimmed = line.trim().toLowerCase()
+    const found = LABELS.find(({ re }) => re.test(trimmed))
+    return found ? found.group : null
+}
+
+const CHORD_TOKEN_RE = /^[A-H](?:#|b)?(?:m|maj|min|dim|aug|sus|add)?\d*(?:-[A-H](?:#|b)?(?:m|maj|min|dim|aug|sus|add)?\d*)?(?:\/[A-H](?:#|b)?)?$/i
+
+function tokenizeLine(line: string): { token: string; index: number }[] {
+    const tokens: { token: string; index: number }[] = []
+    const re = /\S+/g
+    let match: RegExpExecArray | null
+    while ((match = re.exec(line))) tokens.push({ token: match[0], index: match.index })
+    return tokens
+}
+
+function isChordOnlyLine(line: string): boolean {
+    if (!line.trim()) return false
+    const tokens = tokenizeLine(line)
+    if (!tokens.length) return false
+    // Requires every token to be chord-shaped, since holychords.pro cleanly separates chord/lyric lines - one stray token (e.g. "2x") demotes the whole line to lyrics.
+    return tokens.every(({ token }) => CHORD_TOKEN_RE.test(token))
+}
+
+// Unlike txt.ts's insertChordsIntoLyrics(), this doesn't nudge chords off spaces - stays faithful to the site's own column positions.
+function mergeChordAndLyric(chordLine: string, lyricLine: string): string {
+    const tokens = tokenizeLine(chordLine)
+    if (!tokens.length) return lyricLine
+
+    let result = ""
+    let tokenIndex = 0
+    for (let pos = 0; pos < lyricLine.length; pos++) {
+        while (tokenIndex < tokens.length && tokens[tokenIndex].index <= pos) {
+            result += `[${tokens[tokenIndex].token}]`
+            tokenIndex++
+        }
+        result += lyricLine[pos]
+    }
+    // any tokens positioned past the end of the (often shorter) lyric line are appended last
+    while (tokenIndex < tokens.length) {
+        result += `[${tokens[tokenIndex].token}]`
+        tokenIndex++
+    }
+
+    return result
+}
+
+function chordOnlyLineToBrackets(line: string): string {
+    // Trailing space keeps a single-token line's text non-empty after bracket extraction, so txt.ts's empty-text check doesn't wipe the chord too.
+    return (
+        tokenizeLine(line)
+            .map(({ token }) => `[${token}]`)
+            .join(" ") + " "
+    )
+}
+
+function processSectionLines(lines: string[]): string[] {
+    const output: string[] = []
+    let i = 0
+
+    while (i < lines.length) {
+        const line = lines[i]
+
+        if (isChordOnlyLine(line)) {
+            const next = lines[i + 1]
+            if (next !== undefined && next.trim() !== "" && !isChordOnlyLine(next)) {
+                output.push(mergeChordAndLyric(line, next))
+                i += 2
+                continue
+            }
+
+            output.push(chordOnlyLineToBrackets(line))
+            i += 1
+            continue
+        }
+
+        output.push(line)
+        i += 1
+    }
+
+    return output
+}
+
+export function isHolychords(text: string): boolean {
+    return URL_RE.test(text || "")
+}
+
+export function preprocessHolychords(text: string): { name: string; text: string } {
+    const lines = (text || "").replace(/\r/g, "").split("\n")
+
+    const titleIndex = lines.findIndex((line) => line.trim() !== "")
+    const name = titleIndex >= 0 ? lines[titleIndex].trim() : ""
+    if (titleIndex >= 0) lines.splice(titleIndex, 1)
+
+    // Kept aside as a notes= metadata line rather than left in the lyrics.
+    let sourceUrl = ""
+    const urlIndex = lines.findIndex((line) => URL_RE.test(line))
+    if (urlIndex >= 0) {
+        sourceUrl = lines[urlIndex].trim()
+        lines.splice(urlIndex, 1)
+    }
+
+    while (lines.length && lines[0].trim() === "") lines.shift()
+    while (lines.length && lines[lines.length - 1].trim() === "") lines.pop()
+
+    const sections = lines
+        .join("\n")
+        .split(/\n{2,}/)
+        .map((section) => section.split("\n"))
+
+    const processedSections = sections.map((sectionLines) => {
+        while (sectionLines.length && sectionLines[sectionLines.length - 1].trim() === "") sectionLines.pop()
+        if (!sectionLines.length) return []
+
+        const labelGroup = matchLabel(sectionLines[0])
+        if (labelGroup) return [`${labelGroup}:`, ...processSectionLines(sectionLines.slice(1))]
+
+        return processSectionLines(sectionLines)
+    })
+
+    let result = processedSections
+        .map((sectionLines) => sectionLines.join("\n"))
+        .filter((section) => section.trim() !== "")
+        .join("\n\n")
+
+    // Attached to the last section (single "\n") rather than its own "\n\n" section - a separate section would survive as a stray empty slide downstream.
+    if (sourceUrl) result += `${result ? "\n" : ""}notes=${sourceUrl}`
+
+    return { name, text: result }
+}

--- a/src/frontend/converters/txt.ts
+++ b/src/frontend/converters/txt.ts
@@ -11,6 +11,7 @@ import { linesToTextboxes } from "../components/show/formatTextEditor"
 import { VIRTUAL_BREAK_CHAR } from "../show/slides"
 import { activePopup, activeProject, activeShow, alertMessage, dictionary, drawerTabsData, formatNewShow, groupNumbers, groups, special, splitLines } from "../stores"
 import { translateText } from "../utils/language"
+import { isHolychords, preprocessHolychords } from "./holychords"
 import { setTempShows } from "./importHelpers"
 
 export function getQuickExample() {
@@ -47,6 +48,17 @@ export function convertTexts(files: { content: string; name?: string; extension?
 // convert a plain text input into a show
 // , onlySlides: boolean = false, { existingSlides } = { existingSlides: {} }
 export function convertText({ name = "", origin = "", category = null, text, noFormatting = false, returnData = false, open = true }: any) {
+    if (isHolychords(text)) {
+        try {
+            const holychords = preprocessHolychords(text)
+            text = holychords.text
+            if (!name) name = holychords.name
+            if (!origin) origin = "holychords"
+        } catch (err) {
+            console.error("Failed to parse holychords.pro paste", err)
+        }
+    }
+
     // remove empty spaces (as groups [] should be used for empty slides)
     // in "Text edit" spaces can be used to create empty "child" slides
     text = text.replaceAll("\r", "").replaceAll("\n \n", "\n\n")


### PR DESCRIPTION
## Summary

holychords.pro is (to my knowledge) the most popular site for Slavic worship song lyrics/chords, but pasting its output into FreeShow currently just produces one unlabeled blob of text — no verse/chorus groups, no chords.

This adds a small parser that detects a holychords.pro paste and rewrites it into the format FreeShow's existing lyrics importer already understands:

- Ukrainian/Russian section labels (Куплет, Приспів, Інтро, Бридж) become Verse/Chorus/Intro/Bridge groups
- The site's chord notation (H instead of B, hyphenated combo chords like Em-D) is preserved as-is and positioned correctly against the lyrics
- Falls back to the plain-text importer if anything about the pasted format doesn't match what's expected, so it never breaks a paste

## How it works

- `src/frontend/converters/holychords.ts` — detects the holychords.pro URL in pasted text and rewrites labels/chords into the plain-text format the importer already handles
- One small addition to `convertText()` in `src/frontend/converters/txt.ts` wires it in — covers every existing paste flow (Quick Lyrics, clipboard paste, .txt drag-drop) with no other changes needed