### PR TITLE
Fix PDF text export layout for multi-page songs

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "@types/exif": "^0.6.5",
         "@types/express": "^4.17.23",
         "@types/follow-redirects": "^1.14.4",
+        "@types/node": "24.3.0",
         "@types/tmp": "^0.2.6",
         "@types/vimeo__player": "^2.18.3",
         "@types/xml2js": "^0.4.14",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
         "@types/exif": "^0.6.5",
         "@types/express": "^4.17.23",
         "@types/follow-redirects": "^1.14.4",
-        "@types/node": "24.3.0",
         "@types/tmp": "^0.2.6",
         "@types/vimeo__player": "^2.18.3",
         "@types/xml2js": "^0.4.14",

--- a/src/frontend/components/export/Pdf.svelte
+++ b/src/frontend/components/export/Pdf.svelte
@@ -414,7 +414,7 @@
                             </div>
                         {/if}
                         {#each layoutSlides[show.id || ""] as slide, i}
-                            <div class="slide" class:padding={options.type !== "slides" ? i === 0 : i < options.grid[0]} style={options.type !== "text" ? `height: calc(100vh / ${options.grid[1]} - 0.1px);` + (options.type !== "slides" ? "" : `width: calc(100% / ${options.grid[0]});`) : ""}>
+                            <div class="slide" class:padding={options.type === "text" ? true : options.type !== "slides" ? i === 0 : i < options.grid[0]} class:no-break={options.type === "text"} style={options.type !== "text" ? `height: calc(100vh / ${options.grid[1]} - 0.1px);` + (options.type !== "slides" ? "" : `width: calc(100% / ${options.grid[0]});`) : ""}>
                                 <!-- TODO: different slide heights! -->
                                 <!-- style={settings.slides ? `height: calc(842pt / ${settings.grid[1]});` : "" + settings.text ? "" : `width: calc(100% / ${settings.grid[0]});`} -->
                                 {#if options.groups}
@@ -477,12 +477,19 @@
                         {/if}
                     {/if}
                     {#if options.metadata}
-                        <div style="position: absolute;top: calc(100vh * {showPages} - 25px);width: 100%;">
-                            <p style="text-align: center;font-size: 12px;opacity: 0.8;">
-                                <!-- metaDisplay is only used here temporarily -->
+                        {#if options.type === "text"}
+                            <!-- text export flows freely, so its real height isn't a multiple of 100vh - render in normal flow instead of guessing an absolute offset -->
+                            <p style="text-align: center;font-size: 12px;opacity: 0.8;margin: 20px 0 0;">
                                 {show.metaDisplay}
                             </p>
-                        </div>
+                        {:else}
+                            <div style="position: absolute;top: calc(100vh * {showPages} - 25px);width: 100%;">
+                                <p style="text-align: center;font-size: 12px;opacity: 0.8;">
+                                    <!-- metaDisplay is only used here temporarily -->
+                                    {show.metaDisplay}
+                                </p>
+                            </div>
+                        {/if}
                     {/if}
                 </div>
             {/each}
@@ -552,6 +559,10 @@
     }
     .slide.padding {
         padding-top: 30px;
+    }
+    .slide.no-break {
+        break-inside: avoid;
+        page-break-inside: avoid;
     }
 
     .slide .group {


### PR DESCRIPTION
## Summary

Plain text export positioned the song metadata (title/artist) with an absolute offset calculated from `100vh * number of pages` - that math only holds for the slide-grid export types, which render at a fixed height per page. Text export flows freely, so its actual height isn't a clean multiple of 100vh, and on some page breaks the metadata landed mid-page instead of at the top of its own page, overlapping the previous page's lyrics.

### Before Fix
<img width="500" height="273" alt="Pre-fix" src="https://github.com/user-attachments/assets/0ce8a548-ed38-4d40-bb91-a1f06ef81d3b" />

### After Fix
<img width="500" height="288" alt="Post-fix" src="https://github.com/user-attachments/assets/67a85de3-73b0-440d-bc37-76af5b9924e6" />

- Metadata now renders in normal document flow for text exports instead of guessing an absolute position
- Slide content no longer splits across a page break when printing to PDF (`break-inside: avoid`)