### PR TITLE
Show B1 plan item assignees in section notes

### DIFF
--- a/src/electron/contentProviders/churchApps/ChurchAppsImport.ts
+++ b/src/electron/contentProviders/churchApps/ChurchAppsImport.ts
@@ -47,7 +47,7 @@ export class ChurchAppsImport {
         const projectItems: any[] = []
         const planItems: any = await ChurchAppsConnect.apiRequest({
             api: "doing",
-            authenticated: false,
+            authenticated: true,
             scope: "plans",
             endpoint: `/planItems/presenter/${plan.churchId}/${plan.id}`
         })
@@ -61,7 +61,7 @@ export class ChurchAppsImport {
                     id: uid(5),
                     name: pi.label || "",
                     scheduleLength: pi.seconds,
-                    notes: pi.description || ""
+                    notes: [pi.description, pi.assignees].filter(Boolean).join("\n")
                 })
 
                 for (const child of pi.children || []) {


### PR DESCRIPTION
Sends the ChurchApps token on the plan items sync and appends each item's assignees (people scheduled for the position linked to that item in B1) to the section notes, so {project_section_notes} can drive a presenter overlay that follows the current section. Depends on ChurchApps/Api#132. Closes #3675.