### PR TITLE
Serve every output on its own HTML output URL

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1468,7 +1468,12 @@
         "preview_frame_rate": "Preview frame rate",
         "auto": "Auto",
         "section_trigger_action": "Trigger action when navigating presentation to a section",
-        "rss": "RSS"
+        "rss": "RSS",
+        "html_output": "HTML Output",
+        "url_path": "URL Path",
+        "html_output_url": "HTML Output URL",
+        "html_path_taken": "Another output already uses this URL path.",
+        "html_server_disabled": "Enable the \"OutputShow\" server under the Connection tab to use HTML outputs."
     },
     "gpu": {
         "no_acceleration": "Graphics acceleration is unavailable",

--- a/src/electron/capture/helpers/CaptureTransmitter.ts
+++ b/src/electron/capture/helpers/CaptureTransmitter.ts
@@ -5,6 +5,7 @@ import { BlackmagicSender } from "../../blackmagic/BlackmagicSender"
 import { NdiSender } from "../../ndi/NdiSender"
 import util from "../../ndi/vingester-util"
 import { OutputHelper } from "../../output/OutputHelper"
+import { slugifyStreamPath } from "../../output/OutputStreamRouter"
 import { getConnections, getStageStreamSubscriberIds, toServer, toStageStreamSubscribers } from "../../servers"
 import { RtmpStreamer } from "../../streaming/RtmpStreamer"
 import { WebRtcHost } from "../../streaming/WebRtcHost"
@@ -565,9 +566,15 @@ export class CaptureTransmitter {
         const size = image.getSize()
         if (this.shouldSkipUnchangedNonBlackmagicFrame("server", outputId, buffer, size)) return
 
+        // the client displaying this output is identified by the URL path it opened (falls back to the output name)
+        const output = OutputHelper.getOutput(outputId)
+        const name = output?.name || ""
+        const path = output?.htmlData?.path || `/${slugifyStreamPath(name) || "output"}`
+        const transparent = output?.transparent ?? false
+
         /*  convert from ARGB/BGRA (Electron/Chromium capture output) to RGBA (Web canvas)  */
         this.convertToRGBA(buffer)
-        toServer(OUTPUT_STREAM, { channel: "STREAM", data: { id: outputId, time: Date.now(), buffer, size } })
+        toServer(OUTPUT_STREAM, { channel: "STREAM", data: { id: outputId, path, name, transparent, time: Date.now(), buffer, size } })
     }
 
     // WEBRTC

--- a/src/electron/data/defaults.ts
+++ b/src/electron/data/defaults.ts
@@ -25,7 +25,8 @@ export const defaultSettings: { [key in SaveListSettings]: any } = {
             bounds: { x: 0, y: 0, width: 1920, height: 1080 },
             screen: null,
             style: "default",
-            show: {}
+            show: {},
+            htmlData: { path: "/primary" }
         }
     },
     sorted: {},

--- a/src/electron/output/Output.ts
+++ b/src/electron/output/Output.ts
@@ -4,6 +4,7 @@ import type { CaptureOptions } from "../capture/CaptureOptions"
 
 export class Output {
     window!: BrowserWindow
+    name?: string
     osr?: boolean // captured via offscreen paint events instead of the capturePage poll
     // shared-render (FS_SHARE_RENDER): this output is a FOLLOWER sharing `renderGroupRenderer`'s window +
     // capture (pixel-identical content). It owns no window and is fed by the renderer's fan-out.
@@ -16,6 +17,7 @@ export class Output {
     transparent?: boolean
     webrtcData?: any
     rtmpData?: RtmpData
+    htmlData?: any
     // previewWindow: BrowserWindow
     captureOptions?: CaptureOptions
     /*

--- a/src/electron/output/OutputStreamRouter.test.ts
+++ b/src/electron/output/OutputStreamRouter.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { OutputStreamRouter, slugifyStreamPath, STREAM_FRAME_ACK_TIMEOUT } from "./OutputStreamRouter"
+
+const outputA = { id: "out-a", path: "/primary", name: "Primary" }
+const outputB = { id: "out-b", path: "/stage-left", name: "Stage Left" }
+
+describe("slugifyStreamPath", () => {
+    it("matches paths, names and ids to the same slug", () => {
+        expect(slugifyStreamPath("/Stage Left")).toBe("stage-left")
+        expect(slugifyStreamPath("Stage Left")).toBe("stage-left")
+        expect(slugifyStreamPath("/stage-left/")).toBe("stage-left")
+        expect(slugifyStreamPath("/")).toBe("")
+        expect(slugifyStreamPath("")).toBe("")
+    })
+})
+
+describe("OutputStreamRouter", () => {
+    beforeEach(() => OutputStreamRouter.reset())
+
+    it("routes each output only to the clients watching that output", () => {
+        OutputStreamRouter.addSocket("a")
+        OutputStreamRouter.addSocket("b")
+        OutputStreamRouter.setPath("a", "/primary")
+        OutputStreamRouter.setPath("b", "/stage-left")
+
+        const sockets = ["a", "b"]
+        expect(OutputStreamRouter.getTargets(sockets, outputA)).toEqual(["a"])
+        expect(OutputStreamRouter.getTargets(sockets, outputB)).toEqual(["b"])
+    })
+
+    it("falls back to the output name and id when no path is stored", () => {
+        OutputStreamRouter.addSocket("byName")
+        OutputStreamRouter.addSocket("byId")
+        OutputStreamRouter.setPath("byName", "/stage-left")
+        OutputStreamRouter.setPath("byId", "/out-b")
+
+        const targets = OutputStreamRouter.getTargets(["byName", "byId"], { id: outputB.id, name: outputB.name })
+        expect(targets).toEqual(["byName", "byId"])
+    })
+
+    it("sends nothing to a client whose path matches no output", () => {
+        OutputStreamRouter.addSocket("a")
+        OutputStreamRouter.setPath("a", "/does-not-exist")
+
+        expect(OutputStreamRouter.getTargets(["a"], outputA)).toEqual([])
+    })
+
+    it("gives root clients the output selected in the server settings", () => {
+        OutputStreamRouter.addSocket("root")
+        OutputStreamRouter.setPath("root", "/")
+
+        expect(OutputStreamRouter.getTargets(["root"], outputA, outputA.id)).toEqual(["root"])
+        expect(OutputStreamRouter.getTargets(["root"], outputB, outputA.id)).toEqual([])
+    })
+
+    it("sends nothing until a new client announced which output it wants", () => {
+        OutputStreamRouter.addSocket("a", 1000)
+
+        // would otherwise briefly render another output before the subscription arrives
+        expect(OutputStreamRouter.getTargets(["a"], outputA, "", 1100)).toEqual([])
+
+        OutputStreamRouter.setPath("a", "/primary")
+        expect(OutputStreamRouter.getTargets(["a"], outputA, "", 1200)).toEqual(["a"])
+    })
+
+    it("falls back to the root output for clients that never announce a path", () => {
+        OutputStreamRouter.addSocket("old", 1000)
+
+        expect(OutputStreamRouter.getTargets(["old"], outputA, outputA.id, 1100)).toEqual([])
+        expect(OutputStreamRouter.getTargets(["old"], outputA, outputA.id, 9000)).toEqual(["old"])
+    })
+
+    it("keeps root clients on a single output when none is selected", () => {
+        OutputStreamRouter.addSocket("root")
+        OutputStreamRouter.setPath("root", "/")
+
+        // the first output that streams claims the root path, so it does not flip between outputs
+        expect(OutputStreamRouter.getTargets(["root"], outputB, "", 1000)).toEqual(["root"])
+        expect(OutputStreamRouter.getTargets(["root"], outputA, "", 1000)).toEqual([])
+        expect(OutputStreamRouter.getTargets(["root"], outputB, "", 1100)).toEqual(["root"])
+
+        // another output takes over once that one stops streaming
+        expect(OutputStreamRouter.getTargets(["root"], outputA, "", 9000)).toEqual(["root"])
+        expect(OutputStreamRouter.getTargets(["root"], outputB, "", 9100)).toEqual([])
+    })
+
+    it("waits for an acknowledgement before sending the next frame of the same output", () => {
+        expect(OutputStreamRouter.claimFrame("a", outputA.id, 1000)).toBe(true)
+        expect(OutputStreamRouter.claimFrame("a", outputA.id, 1050)).toBe(false)
+
+        OutputStreamRouter.acknowledge("a", outputA.id)
+        expect(OutputStreamRouter.claimFrame("a", outputA.id, 1100)).toBe(true)
+    })
+
+    it("does not let one output or one client block another", () => {
+        expect(OutputStreamRouter.claimFrame("a", outputA.id, 1000)).toBe(true)
+        // different output, same client
+        expect(OutputStreamRouter.claimFrame("a", outputB.id, 1000)).toBe(true)
+        // same output, different client
+        expect(OutputStreamRouter.claimFrame("b", outputA.id, 1000)).toBe(true)
+    })
+
+    it("resumes streaming when a client stops acknowledging", () => {
+        expect(OutputStreamRouter.claimFrame("a", outputA.id, 1000)).toBe(true)
+        expect(OutputStreamRouter.claimFrame("a", outputA.id, 1000 + STREAM_FRAME_ACK_TIMEOUT)).toBe(true)
+    })
+
+    it("drops pending frames when a client switches output or disconnects", () => {
+        OutputStreamRouter.addSocket("a")
+        OutputStreamRouter.setPath("a", "/primary")
+        expect(OutputStreamRouter.claimFrame("a", outputA.id, 1000)).toBe(true)
+
+        OutputStreamRouter.setPath("a", "/stage-left")
+        expect(OutputStreamRouter.claimFrame("a", outputA.id, 1050)).toBe(true)
+        expect(OutputStreamRouter.getTargets(["a"], outputA)).toEqual([])
+
+        // disconnecting clears the stored path and any frame still waiting for an acknowledgement
+        expect(OutputStreamRouter.claimFrame("a", outputB.id, 1050)).toBe(true)
+        OutputStreamRouter.removeSocket("a")
+        expect(OutputStreamRouter.claimFrame("a", outputB.id, 1060)).toBe(true)
+        expect(OutputStreamRouter.getTargets(["a"], outputA, outputA.id)).toEqual(["a"]) // untracked = root client
+    })
+})

--- a/src/electron/output/OutputStreamRouter.ts
+++ b/src/electron/output/OutputStreamRouter.ts
@@ -1,0 +1,99 @@
+// OutputShow (OUTPUT_STREAM) clients each display one specific output, chosen by the URL path they opened.
+// Frames are therefore routed to the sockets watching that output instead of broadcast to every client,
+// which is what previously made every HTML output URL show the same (single captured) output.
+
+// resend a frame even if the client never acknowledged the previous one (client stalled/reloaded)
+export const STREAM_FRAME_ACK_TIMEOUT = 2000
+// let another output take over the root path if the current one stopped streaming
+const ROOT_OUTPUT_TIMEOUT = 3000
+// time a freshly connected client gets to tell us which output it wants before it is treated as a root client
+const SUBSCRIBE_GRACE = 1500
+
+export function slugifyStreamPath(value: string) {
+    return (value || "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+}
+
+export type StreamFrameData = { id?: string; path?: string; name?: string }
+
+export class OutputStreamRouter {
+    private static clients: { [socketId: string]: { path: string | null; connectedAt: number } } = {} // path: slugified ("" = root, null = not announced yet)
+    private static pending: { [key: string]: number } = {} // `${socketId}|${outputId}`: time the frame was sent
+    private static rootOutputId = "" // output currently shown on the root path when none is selected in the settings
+    private static rootOutputTime = 0
+
+    static reset() {
+        this.clients = {}
+        this.pending = {}
+        this.rootOutputId = ""
+        this.rootOutputTime = 0
+    }
+
+    static addSocket(socketId: string, now = Date.now()) {
+        this.clients[socketId] = { path: null, connectedAt: now }
+    }
+
+    static setPath(socketId: string, path: string, now = Date.now()) {
+        this.clients[socketId] = { path: slugifyStreamPath(path), connectedAt: this.clients[socketId]?.connectedAt ?? now }
+        // any frame still in flight belonged to the previously watched output
+        this.clearPending(socketId)
+    }
+
+    static removeSocket(socketId: string) {
+        delete this.clients[socketId]
+        this.clearPending(socketId)
+    }
+
+    static acknowledge(socketId: string, outputId: string) {
+        delete this.pending[`${socketId}|${outputId}`]
+    }
+
+    private static clearPending(socketId: string) {
+        for (const key of Object.keys(this.pending)) {
+            if (key.startsWith(`${socketId}|`)) delete this.pending[key]
+        }
+    }
+
+    // the root path shows a single output (legacy behaviour): the one selected in the OutputShow server settings,
+    // otherwise the first one that streams - so it does not flip between outputs now that several can stream at once
+    private static rootMatches(outputId: string, selectedOutputId: string, now: number): boolean {
+        if (selectedOutputId) return selectedOutputId === outputId
+
+        // let another output take over if the current one stopped streaming
+        if (!this.rootOutputId || this.rootOutputId === outputId || now - this.rootOutputTime > ROOT_OUTPUT_TIMEOUT) {
+            this.rootOutputId = outputId
+            this.rootOutputTime = now
+            return true
+        }
+
+        return false
+    }
+
+    // sockets that should receive a frame from this output
+    static getTargets(socketIds: string[], data: StreamFrameData, rootOutputId = "", now = Date.now()): string[] {
+        const outputSlugs = new Set([slugifyStreamPath(data.path || ""), slugifyStreamPath(data.name || ""), slugifyStreamPath(data.id || "")].filter(Boolean))
+        const rootMatches = this.rootMatches(data.id || "", rootOutputId, now)
+
+        return socketIds.filter((socketId) => {
+            const client = this.clients[socketId]
+            // a client that has not announced its path yet gets nothing until the grace period passes,
+            // so it never briefly renders another output (older clients that never announce fall back to the root output)
+            if (!client) return rootMatches
+            if (client.path === null) return now - client.connectedAt > SUBSCRIBE_GRACE && rootMatches
+
+            return client.path ? outputSlugs.has(client.path) : rootMatches
+        })
+    }
+
+    // only send a new frame once the client responded to the previous one (per socket & output, so a slow client can't stall the others)
+    static claimFrame(socketId: string, outputId: string, now = Date.now()): boolean {
+        const key = `${socketId}|${outputId}`
+        const sentAt = this.pending[key]
+        if (sentAt && now - sentAt < STREAM_FRAME_ACK_TIMEOUT) return false
+
+        this.pending[key] = now
+        return true
+    }
+}

--- a/src/electron/output/helpers/OutputLifecycle.ts
+++ b/src/electron/output/helpers/OutputLifecycle.ts
@@ -123,7 +123,7 @@ export class OutputLifecycle {
         const outputWindow = this.createOutputWindow({ ...renderBounds, alwaysOnTop: output.alwaysOnTop !== false, backgroundColor: output.transparent ? "#00000000" : "#000000" }, id, output.name, output)
         // const previewWindow = this.createPreviewWindow({ ...output.bounds, backgroundColor: "#000000" })
 
-        OutputHelper.setOutput(id, { window: outputWindow, osr: this.isOsrOutput(output), invisible: output.invisible, boundsLocked: output.boundsLocked, screen: output.screen, intendedBounds: resolvedBounds, transparent: output.transparent, webrtcData: output.webrtcData, rtmpData: output.rtmpData })
+        OutputHelper.setOutput(id, { window: outputWindow, name: output.name, osr: this.isOsrOutput(output), invisible: output.invisible, boundsLocked: output.boundsLocked, screen: output.screen, intendedBounds: resolvedBounds, transparent: output.transparent, webrtcData: output.webrtcData, rtmpData: output.rtmpData, htmlData: output.htmlData })
         // OutputHelper.setOutput(id, { window: outputWindow, previewWindow: previewWindow })
         OutputHelper.Bounds.updateBounds({ id: output.id!, bounds: resolvedBounds })
         this.updateWindowConstraints(id)
@@ -134,7 +134,7 @@ export class OutputLifecycle {
             delete this.pendingCaptureStart[id]
 
             if (!CaptureHelper.Lifecycle || !OutputHelper.getOutput(id)) return // window closed before timeout finished
-            CaptureHelper.Lifecycle.startCapture(id, { ndi: output.ndi || false, blackmagic: !!output.blackmagic, webrtc: !!output.webrtcData?.streaming, rtmp: !!output.rtmpData?.streaming })
+            CaptureHelper.Lifecycle.startCapture(id, { ndi: output.ndi || false, blackmagic: !!output.blackmagic, server: !!output.html, webrtc: !!output.webrtcData?.streaming, rtmp: !!output.rtmpData?.streaming })
         }, 1200)
 
         // NDI
@@ -147,10 +147,10 @@ export class OutputLifecycle {
         if (output.blackmagic) initializeSender(output, outputWindow, id)
     }
 
-    // only NDI capture outputs share a render; blackmagic/webrtc/rtmp need dedicated capture,
+    // only NDI capture outputs share a render; blackmagic/webrtc/rtmp/html need dedicated capture,
     // and displayed (non-OSR) outputs need their own window
     private static canShareRender(output: Output): boolean {
-        return !!output.ndi && !output.blackmagic && !output.webrtcData?.streaming && !output.rtmpData?.streaming && this.isOsrOutput(output)
+        return !!output.ndi && !output.blackmagic && !output.webrtcData?.streaming && !output.rtmpData?.streaming && !output.html && this.isOsrOutput(output)
     }
 
     private static async createFollowerOutput(id: string, output: Output, rendererId: string, rendererWindow: BrowserWindow) {

--- a/src/electron/output/helpers/OutputValues.ts
+++ b/src/electron/output/helpers/OutputValues.ts
@@ -27,6 +27,15 @@ const setValues = {
         output.rtmpData = value
         CaptureHelper.Lifecycle.startCapture(id, { rtmp: !!value?.streaming })
     },
+    html: (value: boolean, _window: BrowserWindow, id: string) => {
+        CaptureHelper.Lifecycle.startCapture(id, { server: value })
+    },
+    htmlData: (value: any, _window: BrowserWindow, _id: string, output: OutputWindow) => {
+        output.htmlData = value
+    },
+    name: (value: string, _window: BrowserWindow, _id: string, output: OutputWindow) => {
+        output.name = value
+    },
     capture: (data: { key: string; value: boolean }, _window: BrowserWindow, id: string) => {
         CaptureHelper.Lifecycle.startCapture(id, { [data.key]: data.value })
     },

--- a/src/electron/servers.ts
+++ b/src/electron/servers.ts
@@ -10,6 +10,7 @@ import { CaptureHelper } from "./capture/CaptureHelper"
 import { publishPort, unpublishPorts } from "./data/bonjour"
 import { toApp } from "./index"
 import { OutputHelper } from "./output/OutputHelper"
+import { OutputStreamRouter } from "./output/OutputStreamRouter"
 
 type ServerName = "REMOTE" | "STAGE" | "CONTROLLER" | "OUTPUT_STREAM"
 interface ServerValues {
@@ -59,10 +60,8 @@ function createServerInstance(id: ServerName) {
         // app.get('/media/:token', handleMediaRequest);
     }
 
-    // The join import from 'path' is still needed for this part
-    app.get("/", (_req, res: Response) => res.sendFile(join(__dirname, id.toLowerCase(), "index.html")))
-    // The join import from 'path' is still needed for this part
     app.use(express.static(join(__dirname, id.toLowerCase())))
+    app.get("*", (_req, res: Response) => res.sendFile(join(__dirname, id.toLowerCase(), "index.html")))
 
     const io = new Server(server)
 
@@ -77,6 +76,7 @@ function createServerInstance(id: ServerName) {
     }
     ioServers[id] = io
     if (id === "STAGE") stageStreamSubscribers = {}
+    if (id === "OUTPUT_STREAM") OutputStreamRouter.reset()
 
     // RECEIVE CONNECTION FROM CLIENT
     io.on("connection", (socket) => {
@@ -157,15 +157,23 @@ export function closeServers() {
     })
 }
 
-let responded: { [key: string]: boolean } = {}
 export function toServer(id: ServerName, msg: any) {
-    if (msg.channel === "STREAM") {
-        // only send if responded
-        if (responded[msg.data.id] === false) return
-        responded[msg.data.id] = false
+    const io = ioServers[id]
+    if (!io) return
+
+    if (id === "OUTPUT_STREAM" && msg.channel === "STREAM") {
+        const socketIds = Object.keys(servers.OUTPUT_STREAM?.connections || {})
+        const targets = OutputStreamRouter.getTargets(socketIds, msg.data || {}, getServerData("OUTPUT_STREAM").outputId || "")
+
+        targets.forEach((socketId) => {
+            if (!OutputStreamRouter.claimFrame(socketId, msg.data.id)) return
+            io.to(socketId).emit(id, msg)
+        })
+
+        return
     }
 
-    ioServers[id]?.emit(id, msg)
+    io.emit(id, msg)
 }
 
 export function getConnections(id: ServerName) {
@@ -195,13 +203,16 @@ function initialize(id: ServerName, socket: Socket) {
     toApp(id, { channel: "CONNECTION", id: socket.id, data: { name } })
     servers[id]!.connections[socket.id] = { name }
 
-    // reset with new connection
-    if (id === "OUTPUT_STREAM") responded = {}
+    // until the client tells us which output it wants, treat it as a root client
+    if (id === "OUTPUT_STREAM") OutputStreamRouter.addSocket(socket.id)
 
     // SEND DATA FROM CLIENT TO APP
     socket.on(id, async (msg: Message) => {
         if (msg.channel === "STREAM_DONE") {
-            responded[msg.data.id] = true
+            OutputStreamRouter.acknowledge(socket.id, msg.data?.id)
+        } else if (msg.channel === "STREAM_SUBSCRIBE") {
+            // the client only wants frames from the output matching its URL path
+            OutputStreamRouter.setPath(socket.id, msg.data?.path || "")
         } else if (msg.channel === "OUTPUT_FRAME") {
             const window = OutputHelper.getOutput(msg.data.outputId)?.window
             if (!window || window.isDestroyed()) return
@@ -225,6 +236,7 @@ function disconnect(id: ServerName, socket: Socket) {
     toApp(id, { channel: "DISCONNECT", id: socket.id })
     delete servers[id]!.connections[socket.id]
     if (id === "STAGE") delete stageStreamSubscribers[socket.id]
+    if (id === "OUTPUT_STREAM") OutputStreamRouter.removeSocket(socket.id)
 }
 
 // https://stackoverflow.com/a/59706252

--- a/src/frontend/components/helpers/output.ts
+++ b/src/frontend/components/helpers/output.ts
@@ -742,9 +742,15 @@ export function checkWindowCapture(startup = false) {
 export function shouldBeCaptured(outputId: string, startup = false) {
     const output = get(outputs)[outputId]
     const stageConnectionIds = Object.keys(get(connections).STAGE || {})
+    // any output can be served on its own URL path with "HTML Output" enabled,
+    // in addition to the single output selected in the OutputShow server settings (served on the root path)
+    const outputStreamEnabled = get(disabledServers).output_stream === false
+    const outputStreamViewers = Object.keys(get(connections).OUTPUT_STREAM || {}).length > 0
+    const rootStreamOutputId = get(serverData)?.output_stream?.outputId || getFirstOutput()?.id
     const captures = {
         ndi: !!output.ndi,
-        server: !!(get(disabledServers).output_stream === false && (get(serverData)?.output_stream?.outputId || getFirstOutput()?.id) === outputId),
+        // only capture while a browser is actually connected, so multiple HTML outputs cost nothing when nobody is watching
+        server: !!(outputStreamEnabled && outputStreamViewers && (output.html || rootStreamOutputId === outputId)),
         // only capture while a connected stage client is actually viewing a "current output" mirror (text-only stage displays need no capture)
         stage: !get(disabledServers).stage && stageConnectionIds.length > 0 && stageHasOutput(outputId) && hasStageStreamViewers(stageConnectionIds, outputId),
         webrtc: !!output.webrtc,
@@ -883,7 +889,16 @@ export const defaultOutput: Output = {
     name: "Output",
     color: "#F0008C",
     bounds: { x: 0, y: 0, width: 1920, height: 1080 }, // x: 1920 ?
-    screen: null
+    screen: null,
+    htmlData: { path: "/output" }
+}
+
+export function slugifyPath(name: string): string {
+    const slug = (name || "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+    return slug ? `/${slug}` : "/output"
 }
 
 // WIP history
@@ -904,6 +919,8 @@ export function addOutput(onlyFirst = false, styleId = "", enabled = true, name 
         while (Object.values(output).find((a) => a.name === output[id].name + (n ? " " + n : ""))) n++
         if (n) output[id].name = output[id].name + " " + n
         if (onlyFirst) output[id].name = translateText("theme.primary")
+
+        output[id].htmlData = { path: slugifyPath(output[id].name) }
 
         // show
         if (enabled && !onlyFirst) send(OUTPUT, ["CREATE"], { id, ...output[id] })
@@ -943,6 +960,7 @@ export function enableStageOutput(options: any = {}) {
     const id = uid()
 
     outputs.update((a) => {
+        const stageName = options?.name || "Stage Output"
         a[id] = {
             enabled: true,
             active: true,
@@ -951,6 +969,7 @@ export function enableStageOutput(options: any = {}) {
             color: "#555555",
             bounds,
             screen: null,
+            htmlData: { path: slugifyPath(stageName) },
             ...options
         }
 

--- a/src/frontend/components/main/popups/OutputSetup.svelte
+++ b/src/frontend/components/main/popups/OutputSetup.svelte
@@ -13,6 +13,7 @@
     ]
 
     const networkTypes = [
+        { id: "html", name: translateText("settings.html_output"), icon: "code", tip: "Browser, OBS, vMix" },
         { id: "ndi", name: "NDI®", icon: "ndi", tip: "IP, OBS" },
         { id: "webrtc", name: "WebRTC", icon: "broadcast", tip: "WHIP, restream.io" },
         { id: "rtmp", name: "RTMP", icon: "broadcast", tip: "YouTube, Twitch, Facebook Live" }

--- a/src/frontend/components/settings/tabs/Outputs.svelte
+++ b/src/frontend/components/settings/tabs/Outputs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onDestroy } from "svelte"
+    import { onDestroy, onMount } from "svelte"
     import { uid } from "uid"
     import { BLACKMAGIC, NDI, OUTPUT } from "../../../../types/Channels"
     import { Main } from "../../../../types/IPC/Main"
@@ -7,12 +7,12 @@
     import type { Output, RtmpDestination } from "../../../../types/Output"
     import { AudioAnalyser } from "../../../audio/audioAnalyser"
     import { requestMain, sendMain } from "../../../IPC/main"
-    import { activePage, activePopup, activeStage, activeStyle, alertMessage, currentOutputSettings, ndiData, outputDisplay, outputs, rtmpStatus, saved, settingsTab, special, stageShows, styles, toggleOutputEnabled } from "../../../stores"
+    import { activePage, activePopup, activeStage, activeStyle, alertMessage, currentOutputSettings, disabledServers, ndiData, outputDisplay, outputs, ports, rtmpStatus, saved, settingsTab, special, stageShows, styles, toggleOutputEnabled } from "../../../stores"
     import { newToast } from "../../../utils/common"
     import { translateText } from "../../../utils/language"
     import { destroy, receive, send } from "../../../utils/request"
     import { clone, keysToID, sortByName, sortObject } from "../../helpers/array"
-    import { addRtmpDestination, checkFFmpeg, refreshOut, removeRtmpDestination, startRtmpStreaming, startStreaming, stopRtmpStreaming, stopStreaming, toggleOutput, updateOutputRtmpData, updateOutputWebrtcData, updateRtmpDestination } from "../../helpers/output"
+    import { addRtmpDestination, checkFFmpeg, refreshOut, removeRtmpDestination, slugifyPath, startRtmpStreaming, startStreaming, stopRtmpStreaming, stopStreaming, toggleOutput, updateOutputRtmpData, updateOutputWebrtcData, updateRtmpDestination } from "../../helpers/output"
     import { hasStreamableDestination } from "../../helpers/rtmpDestinations"
     import InputRow from "../../input/InputRow.svelte"
     import Title from "../../input/Title.svelte"
@@ -70,9 +70,11 @@
             if (out.enabled) {
                 // Recreate window for options fixed at creation (transparency, invisibility, capture/OSR mode)
                 const recreateKeys = ["transparent", "invisible", "ndi", "webrtc", "rtmp", "blackmagic"]
+                // values the running output window can be updated with
+                const setValueKeys = ["alwaysOnTop", "html", "htmlData", "name"]
                 if (recreateKeys.includes(key)) {
                     send(OUTPUT, ["CREATE"], { id: outputId, ...out })
-                } else if (key === "alwaysOnTop") {
+                } else if (setValueKeys.includes(key)) {
                     send(OUTPUT, ["SET_VALUE"], { id: outputId, key, value })
                 }
             }
@@ -128,6 +130,38 @@
             activePopup.set("alert")
             saved.set(false)
         }
+    }
+
+    // html
+    // the path is only stored when set explicitly - it otherwise follows the output name (matching the main process fallback)
+    $: htmlPath = currentOutput?.htmlData?.path || slugifyPath(currentOutput?.name || "")
+    // the URL is copied into a browser source on this or another machine, so show the network address like the connection tab does
+    let ip = "localhost"
+    onMount(async () => {
+        ip = ((await requestMain(Main.IP)) || ["localhost"])[0]
+    })
+    $: htmlUrl = `http://${ip}:${$ports?.output_stream || 5513}${htmlPath}`
+    $: htmlPathTaken = !!currentOutput?.html && outputsList.some((a) => a.id !== currentOutput?.id && a.html && (a.htmlData?.path || slugifyPath(a.name || "")) === htmlPath)
+
+    function updateHtmlData(e: any, key: string) {
+        const id = currentOutput?.id
+        if (!id) return
+
+        const newData = clone($outputs[id]?.htmlData || {})
+        let value = e?.detail?.value ?? e?.detail?.id ?? e
+        if (key === "path" && typeof value === "string") {
+            value = slugifyPath(value)
+        }
+
+        newData[key] = value
+        updateOutput("htmlData", newData)
+        saved.set(false)
+    }
+
+    function toggleHtml(value: boolean) {
+        // store the current (name based) path so renaming the output later does not change a URL already in use
+        if (value && !currentOutput?.htmlData?.path) updateHtmlData(htmlPath, "path")
+        updateOutput("html", value)
     }
 
     // webrtc
@@ -387,6 +421,32 @@
         {#if isAlphaSupported()}
             <MaterialToggleSwitch label="settings.alpha_key" checked={currentOutput.blackmagicData?.alphaKey} on:change={(e) => updateBlackmagicData(e.detail, "alphaKey")} />
         {/if}
+    {/if}
+{/if}
+
+<!-- HTML Output - can be enabled on any output, in addition to its other types -->
+<Title label="settings.html_output" icon="code" />
+
+<MaterialToggleSwitch label="settings.enabled" checked={currentOutput?.html === true} defaultValue={false} on:change={(e) => toggleHtml(e.detail)} />
+
+{#if currentOutput?.html}
+    <InputRow>
+        <MaterialTextInput label="settings.url_path" value={htmlPath} placeholder="/main-output" on:change={(e) => updateHtmlData(e.detail, "path")} />
+    </InputRow>
+
+    <div style="margin-bottom: 10px;">
+        <MaterialTextInput label="settings.html_output_url" value={htmlUrl} copyBtn readonly />
+    </div>
+
+    {#if !currentOutput?.ndi}
+        <MaterialToggleSwitch label="settings.transparent" checked={currentOutput?.transparent} defaultValue={false} on:change={(e) => updateOutput("transparent", e.detail)} />
+    {/if}
+
+    {#if htmlPathTaken}
+        <div class="hint">{translateText("settings.html_path_taken")}</div>
+    {/if}
+    {#if $disabledServers.output_stream !== false}
+        <div class="hint">{translateText("settings.html_server_disabled")}</div>
     {/if}
 {/if}
 

--- a/src/frontend/components/settings/tabs/OutputsTabs.svelte
+++ b/src/frontend/components/settings/tabs/OutputsTabs.svelte
@@ -69,11 +69,14 @@
             }
 
             const captureTypeKeys = ["blackmagic", "ndi", "webrtc", "rtmp"]
+            // values the running output window can be updated with
+            const setValueKeys = ["alwaysOnTop", "html", "htmlData", "name"]
             if (out.enabled && (captureTypeKeys.includes(key) || key === "transparent" || key === "invisible")) {
                 if (value && captureTypeKeys.includes(key)) newToast("toast.output_capture_enabled")
                 // Recreate window for options fixed at creation (see Outputs.svelte)
                 send(OUTPUT, ["CREATE"], { id: outputId, ...out })
-            } else if (out.enabled && key === "alwaysOnTop") {
+            } else if (out.enabled && setValueKeys.includes(key)) {
+                if (value && key === "html") newToast("toast.output_capture_enabled")
                 send(OUTPUT, ["SET_VALUE"], { id: outputId, key, value })
             }
 
@@ -120,7 +123,8 @@
         } else {
             let name = ""
             if (networkType && !localType) {
-                if (networkType === "ndi") name = "NDI"
+                if (networkType === "html") name = "HTML Output"
+                else if (networkType === "ndi") name = "NDI"
                 else if (networkType === "webrtc") name = "WebRTC"
                 else if (networkType === "rtmp") name = "RTMP"
             }
@@ -136,7 +140,8 @@
             }
 
             if (localType === "blackmagic") updateOutput("blackmagic", true, outputId)
-            if (networkType === "ndi") updateOutput("ndi", true, outputId)
+            if (networkType === "html") updateOutput("html", true, outputId)
+            else if (networkType === "ndi") updateOutput("ndi", true, outputId)
             else if (networkType === "webrtc") updateOutput("webrtc", true, outputId)
             else if (networkType === "rtmp") updateOutput("rtmp", true, outputId)
 
@@ -158,6 +163,7 @@
     <div class="right-icons">
         {#if !tab.invisible}<Icon id="hdmi" size={0.6} white title={translateText("settings.window")} />{/if}
         {#if tab.blackmagic}<Icon id="blackmagic" size={0.6} white title="Blackmagic Design" />{/if}
+        {#if tab.html}<Icon id="code" size={0.6} white title="HTML Output" />{/if}
         {#if tab.ndi}<Icon id="ndi" size={0.6} white title="NDI" />{/if}
         {#if tab.webrtc}<Icon id="broadcast" size={0.6} white title="WebRTC" />{/if}
         {#if tab.rtmp}<Icon id="broadcast" size={0.6} white title="RTMP" />{/if}

--- a/src/frontend/utils/common.ts
+++ b/src/frontend/utils/common.ts
@@ -1,14 +1,12 @@
 import { get } from "svelte/store"
-import { OUTPUT } from "../../types/Channels"
 import { Main } from "../../types/IPC/Main"
 import type { ErrorLog } from "../../types/Main"
 import { removeDuplicates } from "../components/helpers/array"
 import { getContrast } from "../components/helpers/color"
-import { getActiveOutputs, toggleOutputs } from "../components/helpers/output"
+import { checkWindowCapture, toggleOutputs } from "../components/helpers/output"
 import { sendMain } from "../IPC/main"
-import { activePopup, activeTriggerFunction, autosave, currentWindow, disabledServers, drawer, errorHasOccurred, focusedArea, os, outputs, quickSearchActive, resized, serverData, statusIndicator, theme, themes, toastMessages, version } from "../stores"
+import { activePopup, activeTriggerFunction, autosave, currentWindow, drawer, errorHasOccurred, focusedArea, os, quickSearchActive, resized, statusIndicator, theme, themes, toastMessages, version } from "../stores"
 import { convertAutosave } from "../values/autosave"
-import { send } from "./request"
 import { save } from "./save"
 
 export const DEFAULT_WIDTH = 290 // --navigation-width (global.css) | resized (stores.ts & defaults.ts)
@@ -168,14 +166,8 @@ export function toggleRemoteStream() {
     // get(special).optimizedMode
     if (!isMainWindow()) return
 
-    const value = { key: "server", value: false }
-    let captureOutputId = get(serverData)?.output_stream?.outputId
-    if (!captureOutputId || !get(outputs)[captureOutputId]) captureOutputId = getActiveOutputs(get(outputs), true, true)[0]
-    if (get(disabledServers).output_stream === false) value.value = true
-
-    setTimeout(() => {
-        send(OUTPUT, ["SET_VALUE"], { id: captureOutputId, key: "capture", value })
-    }, 1800)
+    // multiple outputs can stream at once (one per "HTML Output" URL path), so every enabled output is re-evaluated
+    setTimeout(() => checkWindowCapture(true), 1800)
 }
 
 // dev specific commands

--- a/src/frontend/utils/sendData.ts
+++ b/src/frontend/utils/sendData.ts
@@ -36,6 +36,8 @@ export function client(id: Clients, msg: ClientMessage) {
         console.info("SERVER: " + msgId + " connected")
 
         if (id === "STAGE") checkWindowCapture()
+        // start capturing the outputs served over HTTP as soon as someone opens one (startup = no toast on every browser refresh)
+        else if (id === "OUTPUT_STREAM") checkWindowCapture(true)
     } else if (msg.channel === "DISCONNECT") {
         connections.update((c: any) => {
             if (c[id]) delete c[id][msgId]
@@ -45,6 +47,7 @@ export function client(id: Clients, msg: ClientMessage) {
 
         // stop output capture when the last mirror viewer disconnects
         if (id === "STAGE") checkWindowCapture()
+        else if (id === "OUTPUT_STREAM") checkWindowCapture(true)
     } else sendData(id, msg)
 }
 

--- a/src/server/output_stream/App.svelte
+++ b/src/server/output_stream/App.svelte
@@ -30,27 +30,51 @@
     let audioMuted = true
     let showAudioIcon = false
 
+    function slugify(str: string): string {
+        return (str || "")
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, "-")
+            .replace(/^-+|-+$/g, "")
+    }
+
+    let currentPath = slugify(window.location.pathname)
+    let isTransparent = false
+
+    // tell the server which output this client is displaying, so it only receives that output's frames
+    function subscribeToOutput() {
+        socket.emit("OUTPUT_STREAM", { channel: "STREAM_SUBSCRIBE", data: { path: currentPath } })
+    }
+    socket.on("connect", subscribeToOutput)
+    if (socket.connected) subscribeToOutput()
+
     // let initialDelay = 0
     socket.on("OUTPUT_STREAM", (msg) => {
         switch (msg.channel) {
             case "STREAM":
+                if (msg.data?.id) {
+                    socket.emit("OUTPUT_STREAM", { channel: "STREAM_DONE", data: { id: msg.data.id, success: true } })
+                }
+
+                const framePath = slugify(msg.data.path || "")
+                const frameName = slugify(msg.data.name || "")
+                const frameId = (msg.data.id || "").toLowerCase()
+
+                const matches = !currentPath || framePath === currentPath || frameName === currentPath || frameId === currentPath
+                if (!matches) return
+
+                isTransparent = !!msg.data.transparent
+                if (isTransparent) {
+                    document.body.classList.add("transparent")
+                } else {
+                    document.body.classList.remove("transparent")
+                }
+
                 frames++
                 // FPS
                 count++
                 if (!secondsTimeout) startFPS()
 
-                // this did not work well across different devices
-                // if (!initialDelay) {
-                //     // include device time offset / transmission delay
-                //     initialDelay = Date.now() - msg.data.time
-                // } else {
-                //     let timeSinceSent = Date.now() - initialDelay - msg.data.time
-                //     if (timeSinceSent > 5000) return // skip frames if overloaded
-                // }
-
                 capture = msg.data
-
-                socket.emit("OUTPUT_STREAM", { channel: "STREAM_DONE", data: { id: msg.data.id, success: true } })
                 break
             case "AUDIO_BUFFER":
                 if (audioSignal && audioMuted) return
@@ -76,8 +100,8 @@
         if (!canvas) return
 
         ctx = canvas.getContext("2d")
-        canvas.width = width
-        canvas.height = height
+        canvas.width = width || 1920
+        canvas.height = height || 1080
 
         checkSize()
 
@@ -95,14 +119,20 @@
     }
 
     async function updateCanvas() {
-        if (!canvas) return
+        if (!canvas || !capture?.buffer || !capture?.size?.width || !capture?.size?.height) return
+
+        if (canvas.width !== capture.size.width || canvas.height !== capture.size.height) {
+            canvas.width = capture.size.width
+            canvas.height = capture.size.height
+            ctx = canvas.getContext("2d")
+        }
 
         const arr = new Uint8ClampedArray(capture.buffer)
         const pixels = new ImageData(arr, capture.size.width, capture.size.height)
         const bitmap = await createImageBitmap(pixels)
 
         ctx.clearRect(0, 0, canvas.width, canvas.height)
-        ctx.drawImage(bitmap, 0, 0, canvas.width, canvas.height)
+        ctx.drawImage(bitmap, 0, 0)
 
         // Clean up bitmap to prevent memory leaks
         bitmap.close()
@@ -169,7 +199,7 @@
 <svelte:window on:click={click} />
 
 <div class="center" bind:offsetWidth={width} bind:offsetHeight={height}>
-    <canvas class:imgHeight style="aspect-ratio: {capture?.size?.width || 16}/{capture?.size?.height || 9};" class:height={width / height < (capture?.size?.width || 16) / (capture?.size?.height || 9)} class="previewCanvas" bind:this={canvas} />
+    <canvas class:imgHeight class:transparentBackground={isTransparent} style="aspect-ratio: {capture?.size?.width || 16}/{capture?.size?.height || 9};" class:height={width / height < (capture?.size?.width || 16) / (capture?.size?.height || 9)} class="previewCanvas" bind:this={canvas} />
 </div>
 
 {#if clicked}
@@ -250,12 +280,19 @@
         height: 100%;
     }
 
+    :global(body.transparent) {
+        background-color: transparent !important;
+    }
+
     canvas {
         background-color: #000000;
         aspect-ratio: 16/9;
         /* width: 100%; */
         height: 100%;
         /* object-fit: contain; */
+    }
+    canvas.transparentBackground {
+        background-color: transparent !important;
     }
     canvas.height {
         height: initial;

--- a/src/types/Output.ts
+++ b/src/types/Output.ts
@@ -28,6 +28,8 @@ export interface Output {
     webrtcData?: { url?: string; token?: string; streaming?: boolean; fps?: string | number; bitrate?: string | number }
     rtmp?: boolean
     rtmpData?: RtmpData
+    html?: boolean
+    htmlData?: { path?: string }
     forcedResolution?: Resolution
     invisible?: boolean
     taskbar?: boolean


### PR DESCRIPTION
## Problem

The OutputShow server can only ever show one output. Opening it from several browser tabs shows the same output in all of them, whatever URL is used, so there is no way to put a second output into OBS/vMix as a browser source.

Two things cause this:

- `shouldBeCaptured()` enables the `server` capture for a single output only — the one picked in the OutputShow server settings, or the first one. Every other output has that capture turned off.
- `toServer()` broadcasts `STREAM` frames to every connected socket, and the frame acknowledgement (`responded`) is a single flag per output shared by all clients, so a tab watching one output gates the frames of another.

## Change

Any output can now be enabled as an **HTML Output** and gets its own URL path, alongside whatever else it already is (window, NDI, Blackmagic, WebRTC, RTMP).

- **Per-client frame routing** (`src/electron/output/OutputStreamRouter.ts`): frames go only to the sockets watching that output, matched on the URL path (falling back to the output name/id). The client announces its path with a new `STREAM_SUBSCRIBE` message on connect.
- **Per-client acknowledgement**: the "wait for the client to finish the previous frame" gate is now per socket *and* per output, with a 2s timeout, so one slow or stalled client can no longer stop the stream for everyone. Previously a client that stopped acknowledging left the output's flag stuck until a new connection reset it.
- **The root path keeps its old behaviour**: it shows the output selected in the OutputShow server settings, or — when none is selected — the first one that streams, so it does not flip between outputs now that several can stream at once.
- **Capture is viewer-driven**: an output with HTML output enabled is captured only while a browser is actually connected (the same approach the stage "current output" mirror already uses), so extra HTML outputs cost nothing when nobody is watching.
- Deep paths are served by the express catch-all, so `/my-output` returns the client instead of 404.
- Outputs with HTML output enabled are excluded from `canShareRender`, since followers share the renderer's capture and only start NDI.

## UI

Output settings gets an **HTML Output** section (off by default): an enable toggle, an editable URL path (defaults to the output name, then fixed so renaming an output doesn't break a URL already in use), a read-only copyable URL using the machine's network address, a transparency toggle, and hints for a duplicate path or when the OutputShow server is disabled. "HTML Output" is also offered as a network output type when creating an output.

New strings are added to `public/lang/en.json`.

## Testing

- `src/electron/output/OutputStreamRouter.test.ts` — 12 unit tests covering path/name/id matching, the root-path fallback, the acknowledgement gate and its timeout, and subscription changes.
- Manually with three outputs (a window output, a stage output and an invisible NDI output): each URL renders its own output, `/` stays on one output, and closing all browsers stops the capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Qx7pVEcdwPbGbwZWN2zgM
