### PR TITLE
feat(audio): add configurable fade out duration when pausing or stopping music

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1393,6 +1393,7 @@
         "disable_presenter_controller_keys": "Disable presenter controller keys",
         "default_project_name": "Default project name",
         "audio_fade_duration": "Audio fade duration",
+        "music_fade_duration": "Music fade out duration",
         "audio_crossfade": "Audio crossfade",
         "playlist_volume": "Playlist volume",
         "clear_style_background_on_text": "Clear style background when slide is active",

--- a/public/lang/vi.json
+++ b/public/lang/vi.json
@@ -900,6 +900,7 @@
         "disable_presenter_controller_keys": "Vô hiệu hóa các phím điều khiển trình bày",
         "default_project_name": "Tên dự án mặc định",
         "audio_fade_duration": "Thời lượng làm mờ âm thanh",
+        "music_fade_duration": "Thời gian fade nhỏ dần khi tắt nhạc",
         "max_auto_font_size": "Cỡ chữ tự động lớn nhất",
         "resolution": "Độ phân giải",
         "cropping": "Cắt xén",

--- a/src/frontend/audio/audioFading.ts
+++ b/src/frontend/audio/audioFading.ts
@@ -7,6 +7,7 @@ import { activePlaylist, audioPlaylists, isFadingOut, playingAudio, special } fr
 import { AudioPlayer } from "./audioPlayer"
 import { AudioPlaylist } from "./audioPlaylist"
 import { AudioAnalyser } from "./audioAnalyser"
+import { AudioAnalyserMerger } from "./audioAnalyserMerger"
 
 type AudioClearOptions = {
     clearPlaylist?: boolean
@@ -15,6 +16,44 @@ type AudioClearOptions = {
     commonClear?: boolean
     clearTime?: number // effects
     isPlayingNew?: boolean
+}
+
+export const currentlyPausingFade: { [key: string]: { initialVolume: number } } = {}
+
+export function cancelFadePause(id: string) {
+    const info = currentlyPausingFade[id]
+    if (!info) return
+    delete currentlyPausingFade[id]
+
+    stopFade("out_" + id, false)
+
+    const audio = AudioPlayer.getAudio(id)
+    if (audio) {
+        audio.volume = info.initialVolume
+        AudioAnalyser.setSourceVolume(id, info.initialVolume)
+    }
+}
+
+export async function fadePause(id: string, audio: HTMLAudioElement, duration = 5): Promise<boolean> {
+    if (!audio || audio.paused) return true
+
+    const initialVolume = audio.volume > 0 ? audio.volume : (AudioPlayer.getVolume(id) || 1)
+    currentlyPausingFade[id] = { initialVolume }
+
+    const faded = await fadeAudio(id, audio, duration)
+    const wasFading = currentlyPausingFade[id]
+    delete currentlyPausingFade[id]
+
+    if (faded && wasFading && get(playingAudio)[id]?.paused) {
+        audio.pause()
+        audio.volume = initialVolume
+        AudioAnalyser.setSourceVolume(id, initialVolume)
+        if (!AudioAnalyser.shouldAnalyse()) {
+            AudioAnalyserMerger.stop()
+        }
+        return true
+    }
+    return false
 }
 
 export const clearing: string[] = []
@@ -38,7 +77,6 @@ export function clearAudio(audioPath = "", options: AudioClearOptions = {}) {
         return
     }
 
-    const clearTime = options.playlistCrossfade ? 0 : (options.clearTime ?? get(special).audio_fade_duration ?? 1.5)
     let clearIds = audioPath ? [audioPath] : Object.keys(get(playingAudio))
     // don't clear microphones by default
     if (!audioPath && !options.clearMicrophones) {
@@ -52,10 +90,18 @@ export function clearAudio(audioPath = "", options: AudioClearOptions = {}) {
 
         clearing.push(path)
         try {
+            if (currentlyPausingFade[path]) {
+                cancelFadePause(path)
+            }
+
             const audio = AudioPlayer.getAudio(path)
             if (!audio) return deleteAudio(path)
 
-            const faded = await fadeAudio(path, audio, clearTime)
+            const isMusic = AudioPlayer.isMusic(path)
+            const defaultDuration = isMusic ? AudioPlayer.getMusicFadeDuration(path) : (get(special).audio_fade_duration ?? 1.5)
+            const itemClearTime = options.playlistCrossfade ? 0 : (options.clearTime ?? defaultDuration)
+
+            const faded = await fadeAudio(path, audio, itemClearTime)
             if (faded) removeAudio(path)
             else deleteAudio(path)
         } catch {
@@ -199,7 +245,9 @@ export function fadeoutAllPlayingAudio() {
     })
 
     async function fadeoutAudio(path: string, audio: HTMLAudioElement) {
-        const faded = await fadeAudio(path, audio, get(special).audio_fade_duration ?? 1.5)
+        const isMusic = AudioPlayer.isMusic(path)
+        const duration = isMusic ? AudioPlayer.getMusicFadeDuration(path) : (get(special).audio_fade_duration ?? 1.5)
+        const faded = await fadeAudio(path, audio, duration)
         if (faded && !clearing.includes(path)) {
             audio.pause()
             // analyseAudio()

--- a/src/frontend/audio/audioPlayer.ts
+++ b/src/frontend/audio/audioPlayer.ts
@@ -6,11 +6,11 @@ import { customActionActivation } from "../components/actions/actions"
 import { encodeFilePath, getFileName, locateMediaFile, removeExtension } from "../components/helpers/media"
 import { checkNextAfterMedia } from "../components/helpers/showActions"
 import { requestMain, sendMain } from "../IPC/main"
-import { activePlaylist, dictionary, media, outLocked, playingAudio, playingAudioPaths, special } from "../stores"
+import { activePlaylist, audioPlaylists, dictionary, media, outLocked, playingAudio, playingAudioPaths, special } from "../stores"
 import { addToMediaFolder } from "../utils/cloudSync"
 import { AudioAnalyser } from "./audioAnalyser"
 import { AudioAnalyserMerger } from "./audioAnalyserMerger"
-import { clearAudio, clearing, fadeInAudio, fadeOutAudio } from "./audioFading"
+import { cancelFadePause, clearAudio, clearing, currentlyPausingFade, fadeInAudio, fadeOutAudio, fadePause } from "./audioFading"
 import { AudioMultichannel } from "./audioMultichannel"
 import { AudioPlaylist } from "./audioPlaylist"
 import { AudioRoutingManager } from "./routing/audioRoutingManager"
@@ -316,6 +316,10 @@ export class AudioPlayer {
     static play(id: string) {
         if (!this.audioExists(id)) return
 
+        if (currentlyPausingFade[id]) {
+            cancelFadePause(id)
+        }
+
         const audio = this.getAudio(id)
 
         // reset volume in case it's played again while "Mute when video plays" is active
@@ -327,21 +331,50 @@ export class AudioPlayer {
         AudioAnalyserMerger.init()
     }
 
-    static pause(id: string) {
+    static async pause(id: string, immediate = false) {
         if (!this.audioExists(id)) return
 
-        updatePlayingStore(id, "paused", true)
-        this.getAudio(id)?.pause()
+        const audio = this.getAudio(id)
+        if (!audio) return
 
-        if (!AudioAnalyser.shouldAnalyse()) {
-            AudioAnalyserMerger.stop()
+        if (currentlyPausingFade[id]) return
+
+        if (audio.paused) {
+            updatePlayingStore(id, "paused", true)
+            return
+        }
+
+        const isMusic = AudioPlayer.isMusic(id)
+        updatePlayingStore(id, "paused", true)
+
+        if (!immediate && isMusic) {
+            const fadeDuration = AudioPlayer.getMusicFadeDuration(id)
+            if (fadeDuration > 0) {
+                await fadePause(id, audio, fadeDuration)
+            } else {
+                audio.pause()
+                if (!AudioAnalyser.shouldAnalyse()) {
+                    AudioAnalyserMerger.stop()
+                }
+            }
+        } else {
+            if (currentlyPausingFade[id]) {
+                cancelFadePause(id)
+            }
+            audio.pause()
+            if (!AudioAnalyser.shouldAnalyse()) {
+                AudioAnalyserMerger.stop()
+            }
         }
     }
 
     static stop(id: string) {
         if (!this.audioExists(id)) return
 
-        this.pause(id)
+        if (currentlyPausingFade[id]) {
+            cancelFadePause(id)
+        }
+        this.pause(id, true)
         AudioAnalyser.detach(id)
 
         playingAudio.update((a) => {
@@ -516,6 +549,38 @@ export class AudioPlayer {
 
     static getAudioType(path: string, duration: number) {
         return AudioPlayer.getGlobalOptions(path).audioType || (duration < 30 ? "effect" : "music")
+    }
+
+    static isMusic(id: string): boolean {
+        if (!id) return false
+        const playing = this.getPlaying(id)
+        if (playing?.isMic) return false
+        if (playing?.playlistId) return true
+
+        const duration = this.getDurationSync(id) || playing?.audio?.duration || 0
+        return this.getAudioType(id, duration) === "music"
+    }
+
+    static getMusicFadeDuration(id: string): number {
+        const itemFade = get(media)[id]?.fadeDuration
+        if (itemFade !== undefined && itemFade !== null && itemFade !== "" && !isNaN(Number(itemFade))) {
+            return Math.max(0, Number(itemFade))
+        }
+
+        const playlistId = get(playingAudio)[id]?.playlistId || get(activePlaylist)?.id
+        if (playlistId) {
+            const playlist = get(audioPlaylists)[playlistId]
+            if (playlist?.fadeDuration !== undefined && playlist?.fadeDuration !== null && playlist?.fadeDuration !== "" && !isNaN(Number(playlist.fadeDuration))) {
+                return Math.max(0, Number(playlist.fadeDuration))
+            }
+        }
+
+        const globalSpecial = get(special).music_fade_duration
+        if (globalSpecial !== undefined && globalSpecial !== null && globalSpecial !== "" && !isNaN(Number(globalSpecial))) {
+            return Math.max(0, Number(globalSpecial))
+        }
+
+        return 5
     }
 
     static getStartTime(path: string, startAt?: number | undefined) {

--- a/src/frontend/components/drawer/audio/Audio.svelte
+++ b/src/frontend/components/drawer/audio/Audio.svelte
@@ -6,7 +6,7 @@
     import { AudioPlayer } from "../../../audio/audioPlayer"
     import { AudioPlaylist } from "../../../audio/audioPlaylist"
     import { addProjectItem } from "../../../converters/project"
-    import { activePlaylist, activePopup, activeRename, audioFolders, audioPlaylists, drawerTabsData, effectsLibrary, labelsDisabled, media, outLocked, selectAllAudio, selected } from "../../../stores"
+    import { activePlaylist, activePopup, activeRename, audioFolders, audioPlaylists, drawerTabsData, effectsLibrary, labelsDisabled, media, outLocked, selectAllAudio, selected, special } from "../../../stores"
     import { translateText } from "../../../utils/language"
     import Icon from "../../helpers/Icon.svelte"
     import T from "../../helpers/T.svelte"
@@ -341,6 +341,7 @@
             <Metronome />
         {:else if playlist && playlistSettings}
             <div class="settings">
+                <MaterialNumberInput label="settings.music_fade_duration (s)" value={playlist?.fadeDuration ?? ($special.music_fade_duration ?? 5)} min={0} max={30} step={0.5} on:change={(e) => AudioPlaylist.update(active || "", "fadeDuration", e.detail)} />
                 <MaterialNumberInput label="settings.audio_crossfade (s)" value={playlist?.crossfade || 0} max={30} step={0.5} on:change={(e) => AudioPlaylist.update(active || "", "crossfade", e.detail)} />
                 <MaterialNumberInput label="settings.playlist_volume (%)" value={Number(((playlist?.volume || 1) * 100).toFixed(2))} min={1} max={100} on:change={(e) => AudioPlaylist.update(active || "", "volume", e.detail / 100)} />
             </div>

--- a/src/frontend/components/drawer/info/AudioInfo.svelte
+++ b/src/frontend/components/drawer/info/AudioInfo.svelte
@@ -34,6 +34,7 @@
 
 {#if settingsOpened}
     <main style="flex: 1;overflow-x: hidden;padding: 10px;">
+        <MaterialNumberInput label="settings.music_fade_duration (s)" value={$special.music_fade_duration ?? 5} min={0} max={30} step={0.5} on:change={(e) => updateSpecial(e.detail, "music_fade_duration")} />
         <MaterialNumberInput label="settings.audio_fade_duration (s)" value={$special.audio_fade_duration ?? 1.5} max={30} step={0.5} on:change={(e) => updateSpecial(e.detail, "audio_fade_duration")} />
 
         <!-- defaultValue={false}  -->

--- a/src/frontend/components/show/AudioPreview.svelte
+++ b/src/frontend/components/show/AudioPreview.svelte
@@ -3,7 +3,8 @@
     import { AudioAnalyser } from "../../audio/audioAnalyser"
     import { clearAudio } from "../../audio/audioFading"
     import { AudioPlayer } from "../../audio/audioPlayer"
-    import { focusMode, media, outLocked, playingAudio } from "../../stores"
+    import { dictionary, focusMode, media, outLocked, playingAudio, special } from "../../stores"
+    import { translateText } from "../../utils/language"
     import { triggerClickOnEnterSpace } from "../../utils/clickable"
     import Icon from "../helpers/Icon.svelte"
     import { joinTime, secondsToTime } from "../helpers/time"
@@ -242,6 +243,27 @@
             >
                 <Icon id="loop" white={!$media[path]?.loop} size={1.2} />
             </MaterialButton>
+
+            <div title={translateText("settings.music_fade_duration", $dictionary) + " (s)"} style="display: flex; align-items: center; gap: 4px; padding: 0 6px; opacity: 0.85; font-size: 0.85em;">
+                <span style="font-size: 0.8em; opacity: 0.7;">Fade:</span>
+                <input
+                    type="number"
+                    min="0"
+                    max="30"
+                    step="0.5"
+                    style="width: 44px; height: 26px; background: rgba(0,0,0,0.25); color: inherit; border: 1px solid rgba(255,255,255,0.2); border-radius: 4px; padding: 0 4px; text-align: center; font-size: 0.9em;"
+                    value={$media[path]?.fadeDuration ?? ($special.music_fade_duration ?? 5)}
+                    on:change={(e) => {
+                        const val = parseFloat(e.currentTarget.value)
+                        media.update((m) => {
+                            if (!m[path]) m[path] = {}
+                            m[path].fadeDuration = isNaN(val) ? 5 : Math.max(0, val)
+                            return m
+                        })
+                    }}
+                />
+                <span style="font-size: 0.8em; opacity: 0.7;">s</span>
+            </div>
         {/if}
 
         {#if $media[path]?.volume !== undefined && $media[path]?.volume < 1}


### PR DESCRIPTION
## Description
This PR introduces a smooth and configurable fade-out effect when pausing or stopping music tracks (instead of cutting off sound abruptly).

### Changes:
- **Fade on Pause & Stop**: When pausing or stopping music, audio volume smoothly fades out over the configured duration (default: 5s) before pausing.
- **Instant Resumption**: If the user resumes (clicks Play) while the audio is fading out, the fade is immediately canceled and the original volume is restored seamlessly.
- **Configurable Duration**:
  - **Per Track**: In \AudioPreview\, an input allows adjusting the fade duration directly (\Fade: [ 5 ] s\).
  - **Per Playlist**: In playlist settings, users can customize \music_fade_duration\.
  - **Global**: In the Audio drawer settings, \settings.music_fade_duration\ controls the default duration for all music.
  - Setting to \