### PR TITLE
feat(media): add keyboard hotkey shortcuts to media cards

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -801,6 +801,7 @@
         "select_chord": "Select this chord",
         "play_with_shortcut": "Activate with shortcut",
         "press_to_assign": "Press any letter key to assign",
+        "press_to_assign_media": "Press any key (0-9, A-Z, F1-F12) to assign, or Delete to remove",
         "shortcut_existing": "This shortcut is already assigned",
         "play_on_midi": "Activate on MIDI signal",
         "play_on_midi_tip": "Activate this specific slide when receiving chosen MIDI signal",

--- a/public/lang/vi.json
+++ b/public/lang/vi.json
@@ -628,6 +628,12 @@
         "toggle_clock": "Bật/Tắt đồng hồ",
         "move_connections": "Di chuyển tất cả kết nối đến đây"
     },
+    "actions": {
+        "play_with_shortcut": "Kích hoạt bằng phím tắt",
+        "press_to_assign": "Nhấn phím chữ bất kỳ để gán",
+        "press_to_assign_media": "Nhấn phím bất kỳ (0-9, A-Z, F1-F12) để gán, hoặc Delete để xóa",
+        "shortcut_existing": "Phím tắt này đã được gán"
+    },
     "tools": {
         "notes": "Ghi chú",
         "--schedule": "Lịch trình",

--- a/src/frontend/components/context/ContextItem.svelte
+++ b/src/frontend/components/context/ContextItem.svelte
@@ -229,6 +229,12 @@
                 enabled = !!$media[path]?.favourite
             }
         },
+        media_shortcut: () => {
+            let path = $selected.data[0]?.path || $selected.data[0]?.id
+            if (path) {
+                enabled = !!$media[path]?.shortcut
+            }
+        },
         effects_library_add: () => {
             let path = $selected.data[0]?.path || $selected.data[0]?.id
             if (path) {

--- a/src/frontend/components/context/contextMenus.ts
+++ b/src/frontend/components/context/contextMenus.ts
@@ -183,6 +183,7 @@ export const contextMenuItems: { [key: string]: ContextMenuItem } = {
     play: { label: "media.play", icon: "play", iconColor: "#7d81ff" },
     play_no_audio: { label: "media.play_no_audio", icon: "play", iconColor: "#7d81ff" },
     play_no_filters: { label: "media.play_no_filters", icon: "play", iconColor: "#7d81ff" },
+    media_shortcut: { label: "actions.play_with_shortcut", icon: "play", iconColor: "#7d81ff" },
     favourite: { label: "media.favourite", icon: "star", iconColor: "#fff1ad" },
     effects_library_add: { label: "media.effects_library_add", icon: "effect", iconColor: "#fff1ad" },
     createSlideshow: { label: "context.create_slideshow", icon: "slide" },
@@ -288,9 +289,8 @@ export const contextMenuLayouts: { [key: string]: string[] } = {
     show_audio: ["preview", "SEPARATOR", "system_open"],
     slide_recorder_item: ["remove"],
     // , "addToShow"
-    // show_in_explorer!!
     media: ["manage_media_tags", "media_tag_filter", "sort_media_by", "media_view"],
-    media_card: ["GROUP_open", "createSlideshow", "play_no_audio", "play_no_filters", "SEPARATOR", "favourite", "SEPARATOR", "media_tag_set", "media_tag_filter", "sort_media_by", "SEPARATOR", "system_open"],
+    media_card: ["GROUP_open", "createSlideshow", "play_no_audio", "play_no_filters", "SEPARATOR", "media_shortcut", "favourite", "SEPARATOR", "media_tag_set", "media_tag_filter", "sort_media_by", "SEPARATOR", "system_open"],
     // "addToFirstSlide",
     drawer_overlays: ["reset_defaults"],
     overlay_card: ["GROUP_open", "overlay_actions", "display_duration", "SEPARATOR", "lock_to_output", "place_under_slide", "SEPARATOR", "rename", "recolor", "duplicate", "delete"], // "GROUP_rename_color"

--- a/src/frontend/components/context/menuClick.ts
+++ b/src/frontend/components/context/menuClick.ts
@@ -1677,6 +1677,24 @@ const clickActions = {
             return a
         })
     },
+    media_shortcut: (obj: ObjData) => {
+        if (!obj.sel) return
+        const path = obj.sel.data[0]?.path || obj.sel.data[0]?.id
+        if (!path) return
+
+        const existingShortcuts = Object.entries(get(media))
+            .filter(([p, m]) => p !== path && m.shortcut)
+            .map(([p, m]) => m.shortcut!.toLowerCase())
+
+        const data = {
+            path,
+            mode: "media_shortcut",
+            active: get(media)[path]?.shortcut || "",
+            existingShortcuts
+        }
+        popupData.set(data)
+        activePopup.set("assign_shortcut")
+    },
     effects_library_add: (obj: ObjData) => {
         if (!obj.sel) return
 

--- a/src/frontend/components/drawer/media/MediaCard.svelte
+++ b/src/frontend/components/drawer/media/MediaCard.svelte
@@ -230,6 +230,15 @@
     >
         <!-- icons -->
         <div class="icons">
+            {#if $media[path]?.shortcut}
+                <div style="max-width: 100%;">
+                    <div class="button" style="border: 1px solid var(--secondary);">
+                        <Button style="padding: 3px;" redHover title={translateText("actions.remove: actions.play_with_shortcut")} on:click={() => removeStyle("shortcut")}>
+                            <p>{($media[path].shortcut || "").toUpperCase()}</p>
+                        </Button>
+                    </div>
+                </div>
+            {/if}
             {#if isFavourite && active !== "favourites"}
                 <div style="max-width: 100%;">
                     <div class="button">
@@ -323,6 +332,14 @@
     .icons .button {
         background-color: rgb(0 0 0 / 0.6);
         pointer-events: all;
+    }
+    .icons .button p {
+        pointer-events: all;
+        font-weight: bold;
+        text-transform: uppercase;
+        padding: 0 4px;
+        font-size: 1.1em;
+        color: var(--secondary);
     }
     .icons span {
         pointer-events: all;

--- a/src/frontend/components/main/popups/SlideShortcut.svelte
+++ b/src/frontend/components/main/popups/SlideShortcut.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
     import { onMount } from "svelte"
-    import { activePopup, popupData } from "../../../stores"
+    import { activePopup, media, popupData } from "../../../stores"
     import { history } from "../../helpers/history"
     import { getLayoutRef } from "../../helpers/show"
     import MaterialButton from "../../inputs/MaterialButton.svelte"
     import Tip from "../Tip.svelte"
 
+    let path = $popupData.path
     let index = $popupData.index
     let mode = $popupData.mode
     let revert = $popupData.revert
@@ -15,16 +16,36 @@
 
     let layoutRef = mode === "slide_shortcut" ? getLayoutRef() : []
     let slideDataActions = mode === "slide_shortcut" ? layoutRef[index]?.data?.actions || {} : {}
-    let currentShortcut = mode === "slide_shortcut" ? (slideDataActions.slide_shortcut || {}).key : value
+    let currentShortcut = mode === "slide_shortcut" ? (slideDataActions.slide_shortcut || {}).key : mode === "media_shortcut" && path ? $media[path]?.shortcut || value : value
 
     onMount(() => {
         if (mode === "action") popupData.set({ ...$popupData, mode: "" })
         else popupData.set({})
-        if (mode !== "slide_shortcut" && mode !== "global_group" && mode !== "action") activePopup.set(null)
+        if (mode !== "slide_shortcut" && mode !== "global_group" && mode !== "action" && mode !== "media_shortcut") activePopup.set(null)
     })
 
     function keydown(e: KeyboardEvent) {
-        if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return
+        if (e.key === "Escape") {
+            activePopup.set(revert || null)
+            return
+        }
+        if (e.key === "Backspace" || e.key === "Delete") {
+            updateValue("")
+            return
+        }
+
+        if (e.ctrlKey || e.metaKey || e.altKey) return
+
+        if (mode === "media_shortcut") {
+            const isFKey = /^F(?:[1-9]|1[0-2])$/i.test(e.key)
+            const isAlphaNumeric = /^[a-zA-Z0-9]$/.test(e.key)
+            if (!isFKey && !isAlphaNumeric) return
+
+            updateValue(e.key.toUpperCase())
+            return
+        }
+
+        if (e.shiftKey) return
         if (!e.key || e.key.trim().length !== 1 || !isNaN(e.key as any)) return
 
         const isSpecial = [".", ",", "-", "+", "/", "*", "<", ">", "|", "\\", "¨", "'"].includes(e.key)
@@ -35,7 +56,7 @@
 
     let existing = false
     function updateValue(key: string) {
-        if (existingShortcuts.find((a) => a?.toString().toLowerCase() === key)) {
+        if (key && existingShortcuts.find((a: any) => a?.toString().toLowerCase() === key.toLowerCase())) {
             existing = true
             return
         }
@@ -44,8 +65,19 @@
         currentShortcut = key
 
         if (mode === "slide_shortcut") {
-            slideDataActions.slide_shortcut = { key }
+            if (key) {
+                slideDataActions.slide_shortcut = { key }
+            } else {
+                delete slideDataActions.slide_shortcut
+            }
             history({ id: "SHOW_LAYOUT", newData: { key: "actions", data: slideDataActions, indexes: [index] } })
+        } else if (mode === "media_shortcut" && path) {
+            media.update((m) => {
+                if (!m[path]) m[path] = {}
+                if (key) m[path].shortcut = key
+                else delete m[path].shortcut
+                return m
+            })
         } else if (trigger) {
             trigger(key)
         }
@@ -63,7 +95,7 @@
 {#if existing}
     <Tip type="warning" value="actions.shortcut_existing" />
 {:else}
-    <Tip value="actions.press_to_assign" />
+    <Tip value={mode === "media_shortcut" ? "actions.press_to_assign_media" : "actions.press_to_assign"} />
 {/if}
 
 {#if currentShortcut}

--- a/src/frontend/components/output/preview/Preview.svelte
+++ b/src/frontend/components/output/preview/Preview.svelte
@@ -2,7 +2,7 @@
     import { actions, activePage, activePopup, activeShow, activeTimers, contextActive, groups, guideActive, outLocked, outputs, overlayTimers, playingAudio, playingMetronome, resized, slideTimers, special } from "../../../stores"
     import { DEFAULT_WIDTH, isDarkTheme } from "../../../utils/common"
     import { formatSearch } from "../../../utils/search"
-    import { getNormalizedKey, previewCtrlShortcuts, previewShortcuts } from "../../../utils/shortcuts"
+    import { getNormalizedKey, previewCtrlShortcuts, previewShortcuts, triggerMediaShortcut } from "../../../utils/shortcuts"
     import { runAction } from "../../actions/actions"
     import AudioMeter from "../../drawer/audio/AudioMeter.svelte"
     import { getSlideText } from "../../edit/scripts/textStyle"
@@ -67,7 +67,17 @@
                 e.preventDefault()
                 return
             }
+        }
 
+        // play media with custom shortcut key
+        if (!e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey && !$outLocked) {
+            if (triggerMediaShortcut(e)) {
+                e.preventDefault()
+                return
+            }
+        }
+
+        if ((outSlide?.id || $activeShow) && !e.ctrlKey && !e.metaKey && !$outLocked) {
             // play group with custom shortcut keys
             // /^[A-Z]{1}$/i.test(e.key) &&
             if (checkGroupShortcuts(e)) {

--- a/src/frontend/utils/shortcuts.ts
+++ b/src/frontend/utils/shortcuts.ts
@@ -12,7 +12,7 @@ import { keysToID, sortByName } from "../components/helpers/array"
 import { copy, cut, deleteAction, duplicate, paste, selectAll } from "../components/helpers/clipboard"
 import { history, redo, undo } from "../components/helpers/history"
 import { getExtension, getMedia, getMediaLayerType, getMediaStyle, getMediaType } from "../components/helpers/media"
-import { getFirstActiveOutput, refreshOut, setOutput, startFolderTimer, toggleOutputs } from "../components/helpers/output"
+import { getAllActiveOutputs, getFirstActiveOutput, refreshOut, setOutput, startFolderTimer, toggleOutputs } from "../components/helpers/output"
 import { OutputHelper } from "../components/helpers/OutputHelper"
 import { VideoPlayer } from "../components/media/video/videoPlayer"
 import { clearAll, clearBackground, clearSlide } from "../components/output/clear"
@@ -552,3 +552,52 @@ export async function playFolder(path: string, back = false) {
 
     startFolderTimer(path, newMedia)
 }
+
+export function playMediaDirect(path: string) {
+    if (!path) return
+    const activeOutputs = getAllActiveOutputs()
+    const isActive = activeOutputs.some((a) => (a.out?.background?.path || a.out?.background?.id) === path)
+    if (isActive) {
+        clearBackground()
+        return
+    }
+
+    const mediaMap = get(media)
+    const mediaItem = mediaMap[path] || {}
+    const currentOutput = getFirstActiveOutput()
+    const currentStyle = get(styles)[currentOutput?.style || ""] || {}
+    const mediaStyle = getMediaStyle(mediaItem, currentStyle)
+    const type = getMediaType(getExtension(path))
+    const videoType = getMediaLayerType(path, mediaStyle)
+    const loop = videoType === "foreground" ? false : true
+    const muted = videoType === "background" ? true : false
+    if (videoType === "foreground") clearSlide()
+
+    const allStyles = get(styles)
+    activeOutputs.forEach((output) => {
+        const currentOutputStyle = allStyles[output.style || ""]
+        const outputMediaStyle = getMediaStyle(mediaItem, currentOutputStyle)
+        setOutput("background", { path, type, loop, muted, startAt: 0, ...outputMediaStyle, ignoreLayer: videoType === "foreground" }, false, output.id)
+    })
+}
+
+export function triggerMediaShortcut(e: KeyboardEvent | string): boolean {
+    const key = typeof e === "string" ? e : e.key
+    const normalizedKey = typeof e === "string" ? e : getNormalizedKey(e)
+    if (!key) return false
+
+    const mediaMap = get(media)
+    const upperKey = key.toUpperCase()
+    const upperNorm = normalizedKey.toUpperCase()
+
+    const match = Object.entries(mediaMap).find(([path, m]) => {
+        if (!m?.shortcut) return false
+        const s = m.shortcut.toUpperCase()
+        return s === upperKey || s === upperNorm
+    })
+    if (!match) return false
+
+    playMediaDirect(match[0])
+    return true
+}
+

--- a/src/frontend/utils/shortcuts.ts
+++ b/src/frontend/utils/shortcuts.ts
@@ -556,9 +556,9 @@ export async function playFolder(path: string, back = false) {
 export function playMediaDirect(path: string) {
     if (!path) return
     const activeOutputs = getAllActiveOutputs()
-    const isActive = activeOutputs.some((a) => (a.out?.background?.path || a.out?.background?.id) === path)
-    if (isActive) {
-        clearBackground()
+    const matchingOutputs = activeOutputs.filter((a) => (a.out?.background?.path || a.out?.background?.id) === path)
+    if (matchingOutputs.length) {
+        matchingOutputs.forEach((o) => clearBackground(o.id))
         return
     }
 


### PR DESCRIPTION
## Description
This PR adds the ability to assign custom keyboard shortcuts (hotkeys) directly to media items in the Media drawer (similar to vMix media hotkeys).

### Changes
1. **Context Menu**: Added "Activate with shortcut" option when right-clicking any media card thumbnail in the Media drawer.
2. **Assign Shortcut Modal**:
   - Supported keys: digits (0-9), letters (A-Z), and function keys (F1-F12).
   - Pressing Delete or Backspace clears the shortcut.
   - Pressing Escape cancels.
   - Detects and warns if a shortcut key is already assigned to another media card.
3. **Media Card Badge**: Displays a clean badge `[ 1 ]`, `[ A ]`, `[ F6 ]` on the media card thumbnail. Hovering over the badge turns it into a red remove button to quickly clear the shortcut.
4. **Keyboard Playback & Toggle**:
   - Pressing the hotkey plays the media on active outputs (background/foreground).
   - Pressing the same hotkey while the media is active toggles/clears it from output (like vMix Cut).
5. **Localization**: Added translation keys for English and Vietnamese.
