### PR TITLE
Add global manager for Google and local fonts

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -467,6 +467,18 @@
         "bridge": "Bridge",
         "outro": "Outro"
     },
+    "fonts": {
+        "show_hint": "These fonts are saved with this show and appear in its font picker. Removing a font does not change text already using it.",
+        "google_family": "Google Fonts family",
+        "add_google": "Add Google font",
+        "google_hint": "Enter a family name from Google Fonts. An internet connection is required to download the font on each computer.",
+        "add_local": "Add local font file",
+        "local_hint": "Choose a .ttf or .otf file. Local files are referenced, not copied; the same path must be available on other computers.",
+        "loading": "Loading font…",
+        "duplicate": "This font has already been added.",
+        "local_error": "Could not load this font. Choose a valid, accessible .ttf or .otf file.",
+        "google_error": "Could not load this Google font. Check the family name and your internet connection."
+    },
     "popup": {
         "show": "New show",
         "select_show": "Select show",
@@ -533,6 +545,7 @@
         "category_action": "Category action",
         "category_template": "Category template",
         "custom_action": "Custom action",
+        "manage_fonts": "Manage show fonts",
         "slide_midi": "Slide MIDI input",
         "user_data_overwrite": "Found existing data",
         "connect": "Connect",

--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -468,12 +468,12 @@
         "outro": "Outro"
     },
     "fonts": {
-        "show_hint": "These fonts are saved with this show and appear in its font picker. Removing a font does not change text already using it.",
+        "global_hint": "These fonts are available to all shows, overlays and templates on this computer. Removing a font does not change text already using it.",
         "google_family": "Google Fonts family",
         "add_google": "Add Google font",
         "google_hint": "Enter a family name from Google Fonts. An internet connection is required to download the font on each computer.",
         "add_local": "Add local font file",
-        "local_hint": "Choose a .ttf or .otf file. Local files are referenced, not copied; the same path must be available on other computers.",
+        "local_hint": "Choose a .ttf or .otf file. The file is referenced, not copied; keep it at the selected location.",
         "loading": "Loading font…",
         "duplicate": "This font has already been added.",
         "local_error": "Could not load this font. Choose a valid, accessible .ttf or .otf file.",
@@ -545,7 +545,7 @@
         "category_action": "Category action",
         "category_template": "Category template",
         "custom_action": "Custom action",
-        "manage_fonts": "Manage show fonts",
+        "manage_fonts": "Manage fonts",
         "slide_midi": "Slide MIDI input",
         "user_data_overwrite": "Found existing data",
         "connect": "Connect",

--- a/src/frontend/App.svelte
+++ b/src/frontend/App.svelte
@@ -4,6 +4,7 @@
     import ContextMenu from "./components/context/ContextMenu.svelte"
     import Pdf from "./components/export/Pdf.svelte"
     import Guide from "./components/guide/Guide.svelte"
+    import { loadCustomFonts } from "./components/helpers/fonts"
     import { getContrast } from "./components/helpers/color"
     import { getBlending } from "./components/helpers/output"
     import { checkTimers, startEventTimer, startTimer } from "./components/helpers/timerTick"
@@ -18,7 +19,7 @@
     import TooltipManager from "./components/main/TooltipManager.svelte"
     import QuickSearch from "./components/quicksearch/QuickSearch.svelte"
     import Center from "./components/system/Center.svelte"
-    import { activeProfile, activeTimers, closeAd, currentWindow, disabledServers, events, language, loaded, localeDirection, os, outputDisplay, outputs, profiles, theme, themes, timers } from "./stores"
+    import { activeProfile, activeTimers, closeAd, currentWindow, disabledServers, events, globalCustomFonts, language, loaded, localeDirection, os, outputDisplay, outputs, profiles, theme, themes, timers } from "./stores"
     import { focusArea, logerror, mainClick, toggleRemoteStream } from "./utils/common"
     import { keydown } from "./utils/shortcuts"
     import { startup } from "./utils/startup"
@@ -26,6 +27,9 @@
     startup()
 
     $: isWindows = !$currentWindow && $os.platform === "win32"
+
+    // Load global fonts in both the main renderer and every output renderer.
+    $: loadCustomFonts($globalCustomFonts, false)
 
     ///// UPDATERS /////
 

--- a/src/frontend/components/edit/tools/EditValues.svelte
+++ b/src/frontend/components/edit/tools/EditValues.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
     import { createEventDispatcher, onDestroy } from "svelte"
-    import { actions, activeEdit, activePage, activeStage, outputs, special, timers } from "../../../stores"
+    import { actions, activeEdit, activePage, activePopup, activeShow, activeStage, outputs, popupData, showsCache, special, timers } from "../../../stores"
     import { throttle } from "../../../utils/common"
     import { translateText } from "../../../utils/language"
     import { mediaExtensions } from "../../../values/extensions"
     import { getSortedTimers } from "../../drawer/timers/timers"
     import { clone, keysToID, sortByName } from "../../helpers/array"
+    import { loadCustomFonts } from "../../helpers/fonts"
     import Icon from "../../helpers/Icon.svelte"
     import { getFilters, getStyles } from "../../helpers/style"
     import Input from "../../input/Input.svelte"
@@ -30,6 +31,15 @@
     export let item: any = {}
     export let isStage = false
     export let type: string = ""
+
+    $: fontShowId = $activePage === "edit" && !isStage && ($activeEdit.type || "show") === "show" && ($activeShow?.type || "show") === "show" ? $activeShow?.id || $activeEdit.showId || "" : ""
+    $: customFonts = $showsCache[fontShowId]?.settings?.customFonts || []
+    $: if (customFonts.length) loadCustomFonts(customFonts)
+
+    function manageFonts() {
+        popupData.set({ showId: fontShowId })
+        activePopup.set("manage_fonts")
+    }
 
     function getValue(input: EditInput, _updater: any = null) {
         if (!item) return ""
@@ -373,7 +383,10 @@
                                 {@const hasTimelineAction = $special.slideTimelineActive && $activePage === "edit" && ($activeEdit.type || "show") === "show" && SlideTimeline.hasActionAtTime(input.key || "", type, $activeEdit?.items?.length ? $activeEdit.items : [0], timelineUpdater)}
 
                                 {#if input.type === "fontDropdown"}
-                                    <MaterialFontDropdown label={values.label} {value} style={values.style} fontStyleValue={input.styleValue} on:change={(e) => changed(e, input)} on:fontStyle={(e) => changed(e, { ...input, key: "font" })} enableFontStyles />
+                                    <MaterialFontDropdown label={values.label} {value} style={values.style} fontStyleValue={input.styleValue} {customFonts} on:change={(e) => changed(e, input)} on:fontStyle={(e) => changed(e, { ...input, key: "font" })} enableFontStyles />
+                                    {#if fontShowId}
+                                        <MaterialButton icon="settings" title="popup.manage_fonts" on:click={manageFonts} />
+                                    {/if}
                                 {:else if input.type === "toggle"}
                                     <MaterialButton style="min-width: 50px;flex: 1;" title={values.label} on:click={() => toggle(input)}>
                                         <Icon id={values.icon} size={1.2} white />

--- a/src/frontend/components/edit/tools/EditValues.svelte
+++ b/src/frontend/components/edit/tools/EditValues.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { createEventDispatcher, onDestroy } from "svelte"
-    import { actions, activeEdit, activePage, activePopup, activeShow, activeStage, outputs, popupData, showsCache, special, timers } from "../../../stores"
+    import { actions, activeEdit, activePage, activeShow, activeStage, outputs, showsCache, special, timers } from "../../../stores"
     import { throttle } from "../../../utils/common"
     import { translateText } from "../../../utils/language"
     import { mediaExtensions } from "../../../values/extensions"
@@ -35,11 +35,6 @@
     $: fontShowId = $activePage === "edit" && !isStage && ($activeEdit.type || "show") === "show" && ($activeShow?.type || "show") === "show" ? $activeShow?.id || $activeEdit.showId || "" : ""
     $: customFonts = $showsCache[fontShowId]?.settings?.customFonts || []
     $: if (customFonts.length) loadCustomFonts(customFonts)
-
-    function manageFonts() {
-        popupData.set({ showId: fontShowId })
-        activePopup.set("manage_fonts")
-    }
 
     function getValue(input: EditInput, _updater: any = null) {
         if (!item) return ""
@@ -384,9 +379,6 @@
 
                                 {#if input.type === "fontDropdown"}
                                     <MaterialFontDropdown label={values.label} {value} style={values.style} fontStyleValue={input.styleValue} {customFonts} on:change={(e) => changed(e, input)} on:fontStyle={(e) => changed(e, { ...input, key: "font" })} enableFontStyles />
-                                    {#if fontShowId}
-                                        <MaterialButton icon="settings" title="popup.manage_fonts" on:click={manageFonts} />
-                                    {/if}
                                 {:else if input.type === "toggle"}
                                     <MaterialButton style="min-width: 50px;flex: 1;" title={values.label} on:click={() => toggle(input)}>
                                         <Icon id={values.icon} size={1.2} white />

--- a/src/frontend/components/helpers/fonts.test.ts
+++ b/src/frontend/components/helpers/fonts.test.ts
@@ -1,3 +1,4 @@
+import { get } from "svelte/store"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 // A minimal TrueType name table, sufficient to exercise the real metadata parser.
@@ -71,6 +72,45 @@ describe("custom fonts", () => {
         expect(merged.map((font) => font.label)).toEqual(["Arial", "Roboto"])
         expect(system).toHaveLength(1)
         expect(fonts.mergeCustomFontOptions(system, [])).toEqual(system)
+    })
+
+    it("restores global choices from settings while keeping imported fonts local to their show", async () => {
+        const { special, globalCustomFonts } = await import("../../stores")
+        special.set({})
+        expect(get(globalCustomFonts)).toEqual([])
+
+        // Settings loaded at startup use the same store as live output updates.
+        const registered = [{ name: "Global Family", path: "/Fonts/Global.ttf" }]
+        const imported = [{ name: "PPT Family", path: "/Import/PPT.ttf" }]
+        const localBefore = structuredClone(imported)
+        special.set(JSON.parse(JSON.stringify({ customFonts: registered, hideCursor: true })))
+        const options = () => fonts.mergeCustomFontOptions([], get(globalCustomFonts))
+        expect(options().map((option) => option.label)).toEqual(["Global Family"])
+        expect(fonts.mergeCustomFontOptions(options(), imported).map((option) => option.label)).toEqual(["Global Family", "PPT Family"])
+
+        special.update((settings) => ({ ...settings, customFonts: [] }))
+        expect(options()).toEqual([])
+        expect(get(special).hideCursor).toBe(true)
+        expect(imported).toEqual(localBefore)
+        expect(fonts.mergeCustomFontOptions(options(), imported).map((option) => option.label)).toEqual(["PPT Family"])
+        special.set({})
+    })
+
+    it("shares registered Google fonts across global and imported-show loaders", async () => {
+        const font = { name: "Roboto", path: "" }
+        const global = fonts.loadCustomFonts([font], false)
+        const imported = fonts.loadCustomFonts([font])
+        expect(links).toHaveLength(1)
+        await links[0].onload()
+        await Promise.all([global, imported])
+        expect(documentFonts.load).toHaveBeenCalledOnce()
+    })
+
+    it("does not substitute Google fonts for inaccessible global local files", async () => {
+        vi.mocked(fetch).mockRejectedValue(new Error("Missing file"))
+        await fonts.loadCustomFonts([{ name: "Roboto", path: "/missing.ttf" }], false)
+        expect(fetch).toHaveBeenCalledOnce()
+        expect(links).toHaveLength(0)
     })
 
     it("shares in-flight Google loads and encodes the family in the URL", async () => {

--- a/src/frontend/components/helpers/fonts.test.ts
+++ b/src/frontend/components/helpers/fonts.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+// A minimal TrueType name table, sufficient to exercise the real metadata parser.
+function fontBuffer() {
+    const family = "Test Family"
+    const bytes = new ArrayBuffer(46 + family.length * 2)
+    const view = new DataView(bytes)
+    view.setUint32(0, 0x00010000)
+    view.setUint16(4, 1)
+    view.setUint32(12, 0x6e616d65) // name
+    view.setUint32(20, 28)
+    view.setUint32(24, bytes.byteLength - 28)
+    view.setUint16(30, 1)
+    view.setUint16(32, 18)
+    view.setUint16(34, 3) // UTF-16BE
+    view.setUint16(40, 1) // family name
+    view.setUint16(42, family.length * 2)
+    for (let i = 0; i < family.length; i++) view.setUint16(46 + i * 2, family.charCodeAt(i))
+    return bytes
+}
+
+describe("custom fonts", () => {
+    let fonts: typeof import("./fonts")
+    let links: any[]
+    let documentFonts: { add: ReturnType<typeof vi.fn>; load: ReturnType<typeof vi.fn> }
+
+    beforeEach(async () => {
+        vi.resetModules()
+        links = []
+        documentFonts = { add: vi.fn(), load: vi.fn().mockResolvedValue([{}]) }
+        vi.stubGlobal("document", {
+            fonts: documentFonts,
+            createElement: vi.fn(() => ({ remove: vi.fn() })),
+            head: { appendChild: vi.fn((link) => links.push(link)) }
+        })
+        vi.stubGlobal(
+            "FontFace",
+            class {
+                constructor(
+                    public family: string,
+                    public source: unknown,
+                    public descriptors: unknown
+                ) {}
+                async load() {
+                    return this
+                }
+            }
+        )
+        vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => fontBuffer() }))
+        fonts = await import("./fonts")
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+        vi.useRealTimers()
+    })
+
+    it("keeps built-in fonts available when local font access fails", async () => {
+        vi.stubGlobal("window", { queryLocalFonts: vi.fn().mockRejectedValue(new Error("Denied")) })
+        const options = await fonts.getSystemFontsList()
+        expect(options.some((font) => font.label === "CMGSans")).toBe(true)
+    })
+
+    it("merges custom families without duplicating installed fonts or weights", () => {
+        const system = [{ label: "Arial", value: "'Arial'" }]
+        const merged = fonts.mergeCustomFontOptions(system, [
+            { name: "arial", path: "" },
+            { name: "Roboto", path: "" },
+            { name: "Roboto", path: "/Roboto-Bold.ttf" }
+        ])
+        expect(merged.map((font) => font.label)).toEqual(["Arial", "Roboto"])
+        expect(system).toHaveLength(1)
+        expect(fonts.mergeCustomFontOptions(system, [])).toEqual(system)
+    })
+
+    it("shares in-flight Google loads and encodes the family in the URL", async () => {
+        const font = { name: "Roboto & Serif", path: "" }
+        const first = fonts.loadCustomFont(font)
+        expect(fonts.loadCustomFont(font)).toBe(first)
+        expect(links).toHaveLength(1)
+        expect(links[0].href).toContain("family=Roboto%20%26%20Serif:wght@400;700")
+        expect(fetch).not.toHaveBeenCalled()
+        await links[0].onload()
+        await expect(first).resolves.toEqual(font)
+        expect(documentFonts.load).toHaveBeenCalledWith("100px 'Roboto & Serif'")
+        await fonts.loadCustomFont(font)
+        expect(links).toHaveLength(1)
+    })
+
+    it("removes failed stylesheets and permits retry after a network error", async () => {
+        const font = { name: "Roboto", path: "" }
+        const failed = fonts.loadCustomFont(font)
+        const rejection = expect(failed).rejects.toThrow("Could not load Google font")
+        links[0].onerror()
+        await rejection
+        expect(links[0].remove).toHaveBeenCalledOnce()
+        const retry = fonts.loadCustomFont(font)
+        expect(links).toHaveLength(2)
+        await links[1].onload()
+        await expect(retry).resolves.toEqual(font)
+    })
+
+    it("rejects a stylesheet that does not provide the requested font", async () => {
+        documentFonts.load.mockResolvedValue([])
+        const loading = fonts.loadCustomFont({ name: "Missing", path: "" })
+        const rejection = expect(loading).rejects.toThrow()
+        await links[0].onload()
+        await rejection
+        expect(links[0].remove).toHaveBeenCalledOnce()
+    })
+
+    it("times out stalled Google requests", async () => {
+        vi.useFakeTimers()
+        const loading = fonts.loadCustomFont({ name: "Roboto", path: "" })
+        const rejection = expect(loading).rejects.toThrow()
+        await vi.advanceTimersByTimeAsync(15000)
+        await rejection
+        expect(links[0].remove).toHaveBeenCalledOnce()
+    })
+
+    it("reads the actual family from a local file and caches it by path", async () => {
+        const loaded = await fonts.loadCustomFont({ name: "", path: "C:\\Fonts\\Test #1.ttf" })
+        expect(loaded).toEqual({ name: "Test Family", path: "C:\\Fonts\\Test #1.ttf" })
+        expect(fetch).toHaveBeenCalledWith("file:///C:/Fonts/Test%20%231.ttf")
+        expect(documentFonts.add.mock.calls[0][0].family).toBe("Test Family")
+        await fonts.loadCustomFont(loaded)
+        expect(fetch).toHaveBeenCalledOnce()
+        expect(documentFonts.add).toHaveBeenCalledOnce()
+        expect(links).toHaveLength(0)
+    })
+
+    it("rejects malformed local fonts without silently substituting a Google font", async () => {
+        vi.mocked(fetch).mockResolvedValue({ ok: true, arrayBuffer: async () => new ArrayBuffer(3) } as Response)
+        await expect(fonts.loadCustomFont({ name: "Bad", path: "/Bad.ttf" })).rejects.toThrow()
+        expect(documentFonts.add).not.toHaveBeenCalled()
+        expect(links).toHaveLength(0)
+    })
+
+    it("retries inaccessible local files after they become available", async () => {
+        vi.mocked(fetch).mockRejectedValueOnce(new Error("Missing file"))
+        const font = { name: "Test Family", path: "/Test.ttf" }
+        await expect(fonts.loadCustomFont(font)).rejects.toThrow("Missing file")
+        await expect(fonts.loadCustomFont(font)).resolves.toEqual(font)
+        expect(fetch).toHaveBeenCalledTimes(2)
+    })
+
+    it("preserves the PowerPoint import fallback for missing local files", async () => {
+        vi.mocked(fetch).mockRejectedValue(new Error("Missing file"))
+        fonts.loadCustomFonts([{ name: "Roboto", path: "/missing.ttf" }])
+        await vi.waitFor(() => expect(links).toHaveLength(1))
+        await links[0].onload()
+        expect(links[0].href).toContain("family=Roboto:")
+    })
+})

--- a/src/frontend/components/helpers/fonts.ts
+++ b/src/frontend/components/helpers/fonts.ts
@@ -1,3 +1,6 @@
+import type { DropdownOptions } from "../../../types/Input"
+import type { CustomFont } from "../../../types/Show"
+
 export interface Family {
     family: string
     default: number
@@ -129,9 +132,19 @@ export async function getSystemFontsList() {
     })
 
     const loadedFonts = await getFontsList()
-    if (!loadedFonts.length) return []
-
     return addFonts(fonts, loadedFonts).map((a) => ({ label: a.family, value: getFontName(a.family), style: a.fonts[a.default]?.css || (a.family ? `font-family: ${getFontName(a.family)};` : "") }))
+}
+
+export function mergeCustomFontOptions(options: DropdownOptions, fonts: CustomFont[]): DropdownOptions {
+    const merged = [...options]
+    const names = new Set(options.map((option) => option.label?.toLowerCase()))
+    fonts.forEach(({ name }) => {
+        if (!name || names.has(name.toLowerCase())) return
+        names.add(name.toLowerCase())
+        const value = getFontName(name)
+        merged.push({ label: name, value, style: `font-family: ${value};` })
+    })
+    return merged.sort((a, b) => (a.label || "").localeCompare(b.label || ""))
 }
 export function getFontStyleList(font: string) {
     if (!cachedFonts.length) return { fontStyles: [], defaultValue: "" }
@@ -182,38 +195,79 @@ function filePathToURL(filePath: string) {
 
     let fileUrl = filePath.replace(/\\/g, "/").replace(/\0/g, "")
     if (/^[A-Za-z]:\//.test(fileUrl)) fileUrl = "/" + fileUrl
-    return "file://" + encodeURI(fileUrl)
+    return "file://" + encodeURI(fileUrl).replace(/[?#]/g, (character) => encodeURIComponent(character))
 }
 
-export function loadCustomFonts(fonts: { name: string; path: string }[]) {
-    fonts.forEach(async (font) => {
-        try {
-            const fileUrl = filePathToURL(font.path)
+// Shared by previews and output layers: reuse both in-flight and completed loads.
+const customFontLoads = new Map<string, Promise<CustomFont>>()
 
-            const response = await fetch(fileUrl)
-            const arrayBuffer = await response.arrayBuffer()
-            const fontData = extractFontInfo(arrayBuffer)
-            if (!fontData?.family) throw new Error("Unknown font format")
+export function loadCustomFont(font: CustomFont): Promise<CustomFont> {
+    const normalized = { name: font.name.trim(), path: font.path.trim() }
+    const key = normalized.path ? `local:${normalized.path}` : `google:${normalized.name}`
+    const existing = customFontLoads.get(key)
+    if (existing) return existing
 
-            // create the FontFace from the detected SFNT offset
-            const start = typeof fontData.offset === "number" ? fontData.offset : 0
-            const source = new Uint8Array(arrayBuffer, start)
+    const loading = (normalized.path ? loadLocalFont(normalized) : loadGoogleFont(normalized)).catch((error) => {
+        customFontLoads.delete(key)
+        throw error
+    })
+    customFontLoads.set(key, loading)
+    return loading
+}
 
-            const fontStyle = /italic/.test((fontData.subfamily || fontData.fullName || "").toLowerCase()) ? "italic" : "normal"
-            const weight = (fontData as any).weight || getWeightFromStyle((fontData.subfamily || fontData.fullName || "").toLowerCase())
+async function loadLocalFont(font: CustomFont): Promise<CustomFont> {
+    const response = await fetch(filePathToURL(font.path))
+    if (!response.ok) throw new Error("Could not read font file")
+    const arrayBuffer = await response.arrayBuffer()
+    const fontData = extractFontInfo(arrayBuffer)
+    if (!fontData?.family) throw new Error("Unknown font format")
 
-            const fnt = new (FontFace as any)(fontData.family, source, { weight: String(weight), style: fontStyle })
-            await fnt.load()
-            document.fonts.add(fnt)
-        } catch {
-            if (font.name.includes("font")) return
+    const source = new Uint8Array(arrayBuffer, fontData.offset || 0)
+    const fontStyle = /italic/.test((fontData.subfamily || fontData.fullName || "").toLowerCase()) ? "italic" : "normal"
+    const weight = fontData.weight || getWeightFromStyle((fontData.subfamily || fontData.fullName || "").toLowerCase())
+    const face = new FontFace(fontData.family, source, { weight: String(weight), style: fontStyle })
+    await face.load()
+    document.fonts.add(face)
+    return { name: fontData.family, path: font.path }
+}
 
-            // try loading from Google Fonts
-            const link = document.createElement("link")
-            link.rel = "stylesheet"
-            link.href = "https://fonts.googleapis.com/css2?family=" + font.name + ":wght@400;700&display=swap"
-            document.head.appendChild(link)
+function loadGoogleFont(font: CustomFont): Promise<CustomFont> {
+    if (!font.name) return Promise.reject(new Error("Missing font family"))
+    return new Promise((resolve, reject) => {
+        const link = document.createElement("link")
+        link.rel = "stylesheet"
+        link.href = "https://fonts.googleapis.com/css2?family=" + encodeURIComponent(font.name) + ":wght@400;700&display=swap"
+        const timeout = setTimeout(() => fail(), 15000)
+        const fail = () => {
+            clearTimeout(timeout)
+            link.onload = null
+            link.onerror = null
+            link.remove()
+            reject(new Error("Could not load Google font"))
         }
+        link.onerror = fail
+        link.onload = async () => {
+            try {
+                const faces = await document.fonts.load(`100px ${getFontName(font.name)}`)
+                if (!faces.length) return fail()
+                clearTimeout(timeout)
+                link.onload = null
+                link.onerror = null
+                resolve(font)
+            } catch {
+                fail()
+            }
+        }
+        document.head.appendChild(link)
+    })
+}
+
+export function loadCustomFonts(fonts: CustomFont[]) {
+    fonts.forEach((font) => {
+        void loadCustomFont(font).catch(() => {
+            // Preserve the PowerPoint importer's fallback for missing embedded fonts.
+            if (font.path && !font.name.includes("font")) void loadCustomFont({ name: font.name, path: "" }).catch(() => {})
+        })
     })
 }
 

--- a/src/frontend/components/helpers/fonts.ts
+++ b/src/frontend/components/helpers/fonts.ts
@@ -262,13 +262,15 @@ function loadGoogleFont(font: CustomFont): Promise<CustomFont> {
     })
 }
 
-export function loadCustomFonts(fonts: CustomFont[]) {
-    fonts.forEach((font) => {
-        void loadCustomFont(font).catch(() => {
-            // Preserve the PowerPoint importer's fallback for missing embedded fonts.
-            if (font.path && !font.name.includes("font")) void loadCustomFont({ name: font.name, path: "" }).catch(() => {})
-        })
-    })
+export function loadCustomFonts(fonts: CustomFont[], fallbackToGoogle = true) {
+    return Promise.all(
+        fonts.map((font) =>
+            loadCustomFont(font).catch(() => {
+                // Only imported shows should substitute Google Fonts for missing local files.
+                if (fallbackToGoogle && font.path && !font.name.includes("font")) return loadCustomFont({ name: font.name, path: "" }).catch(() => {})
+            })
+        )
+    )
 }
 
 function extractFontInfo(arrayBuffer) {

--- a/src/frontend/components/inputs/MaterialFontDropdown.svelte
+++ b/src/frontend/components/inputs/MaterialFontDropdown.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher, onMount } from "svelte"
     import type { DropdownOptions } from "../../../types/Input"
+    import { globalCustomFonts } from "../../stores"
     import type { CustomFont } from "../../../types/Show"
     import { getFontName, getFontStyleList, getSystemFontsList, mergeCustomFontOptions } from "../helpers/fonts"
     import MaterialDropdown from "./MaterialDropdown.svelte"
@@ -15,7 +16,7 @@
 
     let systemFontsList: DropdownOptions = []
     let fontsStylesList: DropdownOptions = []
-    $: fontOptions = mergeCustomFontOptions(systemFontsList, customFonts)
+    $: fontOptions = mergeCustomFontOptions(systemFontsList, [...$globalCustomFonts, ...customFonts])
 
     onMount(async () => {
         systemFontsList = await getSystemFontsList()

--- a/src/frontend/components/inputs/MaterialFontDropdown.svelte
+++ b/src/frontend/components/inputs/MaterialFontDropdown.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
     import { createEventDispatcher, onMount } from "svelte"
     import type { DropdownOptions } from "../../../types/Input"
-    import { getFontName, getFontStyleList, getSystemFontsList } from "../helpers/fonts"
+    import type { CustomFont } from "../../../types/Show"
+    import { getFontName, getFontStyleList, getSystemFontsList, mergeCustomFontOptions } from "../helpers/fonts"
     import MaterialDropdown from "./MaterialDropdown.svelte"
     import InputRow from "../input/InputRow.svelte"
 
@@ -10,9 +11,11 @@
     export let fontStyleValue = ""
     export let enableFontStyles = false
     export let allowEmpty = false
+    export let customFonts: CustomFont[] = []
 
     let systemFontsList: DropdownOptions = []
     let fontsStylesList: DropdownOptions = []
+    $: fontOptions = mergeCustomFontOptions(systemFontsList, customFonts)
 
     onMount(async () => {
         systemFontsList = await getSystemFontsList()
@@ -43,7 +46,7 @@
 </script>
 
 <InputRow style={$$props.style || ""}>
-    <MaterialDropdown {label} options={systemFontsList} value={quotedValue} style={fontStylesVisible ? "max-width: 85%;" : ""} on:change={change} {allowEmpty} />
+    <MaterialDropdown {label} options={fontOptions} value={quotedValue} style={fontStylesVisible ? "max-width: 85%;" : ""} on:change={change} {allowEmpty} />
     {#if fontStylesVisible}
         <MaterialDropdown label="settings.font_style" disabled={fontsStylesList.length < 2} options={fontsStylesList} value={fontStyleValue || defaultFontStyleValue} on:change={styleChange} onlyArrow />
     {/if}

--- a/src/frontend/components/main/popups/ManageFonts.svelte
+++ b/src/frontend/components/main/popups/ManageFonts.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+    import { onDestroy } from "svelte"
+    import type { CustomFont } from "../../../../types/Show"
+    import { activePopup, popupData, showsCache } from "../../../stores"
+    import { getAccess } from "../../../utils/profile"
+    import { loadCustomFont } from "../../helpers/fonts"
+    import { history } from "../../helpers/history"
+    import T from "../../helpers/T.svelte"
+    import InputRow from "../../input/InputRow.svelte"
+    import MaterialButton from "../../inputs/MaterialButton.svelte"
+    import MaterialFilePicker from "../../inputs/MaterialFilePicker.svelte"
+    import MaterialTextInput from "../../inputs/MaterialTextInput.svelte"
+
+    const showId: string = $popupData.showId || ""
+    $: show = $showsCache[showId]
+    $: fonts = show?.settings?.customFonts || []
+    $: readOnly = !show || show.locked || !canEdit()
+
+    let name = ""
+    let loading = false
+    let error = ""
+    let destroyed = false
+    onDestroy(() => (destroyed = true))
+
+    function canEdit() {
+        const currentShow = $showsCache[showId]
+        const access = getAccess("shows")
+        return !!currentShow && !currentShow.locked && !["read", "none"].includes(access.global) && !["read", "none"].includes(access[currentShow.category || ""])
+    }
+
+    function save(fonts: CustomFont[]) {
+        if (!canEdit()) return
+        history({ id: "UPDATE", newData: { key: "settings", subkey: "customFonts", data: fonts }, oldData: { id: showId }, location: { page: "edit", id: "show_key" } })
+    }
+
+    async function addFont(font: CustomFont) {
+        if (loading || !canEdit()) return
+        error = ""
+        const isDuplicate = (candidate: CustomFont) => (font.path ? candidate.path === font.path : !candidate.path && candidate.name.toLowerCase() === font.name.toLowerCase())
+        if (fonts.some(isDuplicate)) {
+            error = "fonts.duplicate"
+            return
+        }
+        loading = true
+        try {
+            const loaded = await loadCustomFont(font)
+            if (destroyed || !canEdit()) return
+            save([...fonts, loaded])
+            name = ""
+        } catch {
+            error = font.path ? "fonts.local_error" : "fonts.google_error"
+        } finally {
+            loading = false
+        }
+    }
+
+    function addGoogleFont() {
+        const family = name.trim().replace(/\s+/g, " ")
+        if (family) void addFont({ name: family, path: "" })
+    }
+</script>
+
+<div class="font-manager">
+    <p><b>{show?.name || ""}</b></p>
+    <p class="hint"><T id="fonts.show_hint" /></p>
+
+    {#each fonts as font, index}
+        <div class="font-row">
+            <div class="font-details">
+                <b>{font.name}</b>
+                <span class="hint">{font.path || "Google Fonts"}</span>
+            </div>
+            <MaterialButton icon="delete" title="actions.delete" disabled={readOnly || loading} on:click={() => save(fonts.filter((_, i) => i !== index))} />
+        </div>
+    {/each}
+
+    <InputRow>
+        <MaterialTextInput id="google-font-family" label="fonts.google_family" value={name} placeholder="Roboto" disabled={readOnly || loading} on:input={(e) => (name = e.detail)} on:keydown={(e) => e.key === "Enter" && addGoogleFont()} />
+        <MaterialButton icon="add" title="fonts.add_google" disabled={readOnly || loading || !name.trim()} on:click={addGoogleFont}>
+            <T id="fonts.add_google" />
+        </MaterialButton>
+    </InputRow>
+    <p class="hint"><T id="fonts.google_hint" /></p>
+
+    <MaterialFilePicker label="fonts.add_local" value="" filter={{ name: "TrueType / OpenType", extensions: ["ttf", "otf"] }} disabled={readOnly || loading} on:change={(e) => addFont({ name: "", path: e.detail })} />
+    <p class="hint"><T id="fonts.local_hint" /></p>
+
+    {#if loading}
+        <p role="status"><T id="fonts.loading" /></p>
+    {/if}
+    {#if error}
+        <p role="alert"><T id={error} /></p>
+    {/if}
+
+    <MaterialButton variant="outlined" on:click={() => activePopup.set(null)}><T id="actions.close" /></MaterialButton>
+</div>
+
+<style>
+    .font-manager {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+        max-width: 650px;
+    }
+    .font-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+    .font-details {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-width: 0;
+        overflow-wrap: anywhere;
+    }
+    .hint {
+        opacity: 0.7;
+        font-size: 0.85em;
+    }
+</style>

--- a/src/frontend/components/main/popups/ManageFonts.svelte
+++ b/src/frontend/components/main/popups/ManageFonts.svelte
@@ -1,20 +1,18 @@
 <script lang="ts">
     import { onDestroy } from "svelte"
     import type { CustomFont } from "../../../../types/Show"
-    import { activePopup, popupData, showsCache } from "../../../stores"
+    import { activePopup, activeProfile, globalCustomFonts, profiles, special } from "../../../stores"
     import { getAccess } from "../../../utils/profile"
     import { loadCustomFont } from "../../helpers/fonts"
-    import { history } from "../../helpers/history"
     import T from "../../helpers/T.svelte"
     import InputRow from "../../input/InputRow.svelte"
     import MaterialButton from "../../inputs/MaterialButton.svelte"
     import MaterialFilePicker from "../../inputs/MaterialFilePicker.svelte"
     import MaterialTextInput from "../../inputs/MaterialTextInput.svelte"
 
-    const showId: string = $popupData.showId || ""
-    $: show = $showsCache[showId]
-    $: fonts = show?.settings?.customFonts || []
-    $: readOnly = !show || show.locked || !canEdit()
+    $: fonts = $globalCustomFonts
+    $: access = $profiles[$activeProfile || ""]?.access.settings || {}
+    $: readOnly = [access.global, access.general].some((level) => level === "read" || level === "none")
 
     let name = ""
     let loading = false
@@ -23,14 +21,13 @@
     onDestroy(() => (destroyed = true))
 
     function canEdit() {
-        const currentShow = $showsCache[showId]
-        const access = getAccess("shows")
-        return !!currentShow && !currentShow.locked && !["read", "none"].includes(access.global) && !["read", "none"].includes(access[currentShow.category || ""])
+        const access = getAccess("settings")
+        return ![access.global, access.general].some((level) => level === "read" || level === "none")
     }
 
     function save(fonts: CustomFont[]) {
         if (!canEdit()) return
-        history({ id: "UPDATE", newData: { key: "settings", subkey: "customFonts", data: fonts }, oldData: { id: showId }, location: { page: "edit", id: "show_key" } })
+        special.update((settings) => ({ ...settings, customFonts: fonts }))
     }
 
     async function addFont(font: CustomFont) {
@@ -61,8 +58,7 @@
 </script>
 
 <div class="font-manager">
-    <p><b>{show?.name || ""}</b></p>
-    <p class="hint"><T id="fonts.show_hint" /></p>
+    <p class="hint"><T id="fonts.global_hint" /></p>
 
     {#each fonts as font, index}
         <div class="font-row">

--- a/src/frontend/components/output/layers/SlideContent.svelte
+++ b/src/frontend/components/output/layers/SlideContent.svelte
@@ -31,11 +31,10 @@
     export let styleIdOverride = ""
 
     let origin = ""
+    $: if ($showsCache[outSlide.id]?.settings?.customFonts) loadCustomFonts($showsCache[outSlide.id].settings.customFonts || [])
     $: if (outSlide.id) updateShow()
     function updateShow() {
-        // custom fonts
         const currentShow = $showsCache[outSlide.id]
-        if (currentShow?.settings?.customFonts) loadCustomFonts(currentShow.settings.customFonts)
         origin = currentShow?.origin || ""
     }
 

--- a/src/frontend/components/settings/SettingsTools.svelte
+++ b/src/frontend/components/settings/SettingsTools.svelte
@@ -40,6 +40,9 @@
         <MaterialButton variant="outlined" icon="star" on:click={() => open("manage_icons")} small>
             <T id="popup.manage_icons" />
         </MaterialButton>
+        <MaterialButton variant="outlined" icon="text" on:click={() => open("manage_fonts")} small>
+            <T id="popup.manage_fonts" />
+        </MaterialButton>
         <MaterialButton variant="outlined" icon="color" on:click={() => open("manage_colors")} small>
             <T id="popup.manage_colors" />
         </MaterialButton>

--- a/src/frontend/components/show/Slides.svelte
+++ b/src/frontend/components/show/Slides.svelte
@@ -27,6 +27,7 @@
     export let projectIndex = -1
 
     $: currentShow = $showsCache[showId]
+    $: if (currentShow?.settings?.customFonts) loadCustomFonts(currentShow.settings.customFonts)
     $: activeLayout = layout || $showsCache[showId]?.settings?.activeLayout
     $: layoutSlides = currentShow ? getCachedShow(showId, activeLayout, $cachedShowsData)?.layout || [] : []
 
@@ -35,9 +36,6 @@
     onMount(() => {
         // don't double render all slides on first load because of cachedShowsData update
         setTimeout(() => (hasMounted = true), 80)
-
-        // custom fonts
-        if (currentShow?.settings?.customFonts) loadCustomFonts(currentShow.settings.customFonts)
     })
 
     onDestroy(() => {

--- a/src/frontend/stores.ts
+++ b/src/frontend/stores.ts
@@ -3,7 +3,7 @@
 
 import type { Bible } from "json-bible/lib/Bible"
 import type { ICommonTagsResult } from "music-metadata"
-import { type Writable, writable } from "svelte/store"
+import { derived, type Writable, writable } from "svelte/store"
 import type { ContentProviderId } from "../electron/contentProviders/base/types"
 import type { TimecodeMode } from "../electron/timecode/timecode"
 import type { AudioChannelData, AudioStream, MetronomeSettings, Playlist } from "../types/Audio"
@@ -15,7 +15,7 @@ import type { History, HistoryNew } from "../types/History"
 import type { ActiveEdit, Clipboard, Interaction, Media, MediaOptions, NumberObject, OS, Popups, Profiles, Selected, SlidesOptions, Variable } from "../types/Main"
 import type { Folders, Projects, ShowRef } from "../types/Projects"
 import type { Dictionary, Styles, Themes } from "../types/Settings"
-import type { Action, Emitter, ID, Overlays, ShowGroups, ShowList, Shows, ShowType, SlideTimer, Tag, Templates, Timer, Transition, TrimmedShows } from "../types/Show"
+import type { Action, CustomFont, Emitter, ID, Overlays, ShowGroups, ShowList, Shows, ShowType, SlideTimer, Tag, Templates, Timer, Transition, TrimmedShows } from "../types/Show"
 import type { ServerData } from "../types/Socket"
 import type { ActiveStage, StageLayouts } from "../types/Stage"
 import type { BibleCategories, Categories, DrawerTabs, EditMode, SettingsTabs, TopViews } from "../types/Tabs"
@@ -332,6 +332,8 @@ export const sorted: Writable<any> = writable({}) // {}
 export const dataPath: Writable<string> = writable("") // "" // DEPRECATED - only for setting
 export const lockedOverlays: Writable<string[]> = writable([]) // []
 export const special: Writable<any> = writable({}) // {}
+// Persisted and sent to output windows through the existing special settings.
+export const globalCustomFonts = derived(special, ($special): CustomFont[] => $special.customFonts || [])
 
 // SETTINGS
 export const language: Writable<string> = writable("en") // get locale

--- a/src/frontend/utils/popup.ts
+++ b/src/frontend/utils/popup.ts
@@ -54,6 +54,7 @@ import Translate from "../components/main/popups/localization/Translate.svelte"
 import ManageColors from "../components/main/popups/ManageColors.svelte"
 import ManageDynamicValues from "../components/main/popups/ManageDynamicValues.svelte"
 import ManageGroups from "../components/main/popups/ManageGroups.svelte"
+import ManageFonts from "../components/main/popups/ManageFonts.svelte"
 import ManageIcons from "../components/main/popups/ManageIcons.svelte"
 import ManageMetadata from "../components/main/popups/ManageMetadata.svelte"
 import ManageTags from "../components/main/popups/ManageTags.svelte"
@@ -165,6 +166,7 @@ export const popups: { [key in Popups]: ComponentType } = {
     action: Action,
     category_action: CategoryAction,
     custom_action: CustomAction,
+    manage_fonts: ManageFonts,
     slide_midi: SlideMidi,
     connect: Connect,
     cloud_sync: CloudSync,

--- a/src/types/Main.ts
+++ b/src/types/Main.ts
@@ -456,6 +456,7 @@ export type Popups =
     | "action"
     | "category_action"
     | "custom_action"
+    | "manage_fonts"
     | "slide_midi"
     | "connect"
     | "cloud_sync"

--- a/src/types/Show.ts
+++ b/src/types/Show.ts
@@ -7,6 +7,12 @@ export interface Shows {
     [key: string]: Show
 }
 
+export interface CustomFont {
+    name: string
+    // An empty path loads the family from Google Fonts.
+    path: string
+}
+
 export interface Show {
     name: string
     id?: string // this id should not be stored (but often used in the program as a temporary value)
@@ -24,7 +30,7 @@ export interface Show {
         // resolution?: Resolution
         template: null | ID
         customAction?: string // special custom trigger
-        customFonts?: { name: string; path: string }[]
+        customFonts?: CustomFont[]
     }
     timestamps: {
         created: number


### PR DESCRIPTION
Related to #3650.

Reworked following the feedback to make font management global. Adds Settings → General → Manage fonts alongside the existing managers, with Google Fonts and local TTF/OTF files available across shows, overlays, and templates.

Registrations persist in global settings and are loaded in output windows. Existing per-show font support for PowerPoint imports remains intact.

Validation: frontend build and all 13 focused tests pass; Svelte diagnostics match unchanged upstream. Earlier macOS results apply to the previous revision; desktop testing of the new global workflow remains pending.