### PR TITLE
feat(output): add Preview/Program (vMix-style) workflow

### DIFF
--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -181,7 +181,7 @@ function createMain() {
     }
 
     // create window
-    mainWindow = new BrowserWindow({ ...mainOptions, ...options })
+    mainWindow = new BrowserWindow({ ...mainOptions, ...options, show: true })
 
     // ensure correct dimensions regardless of DPI scaling (without this, the window changed size each startup when scale was not 100%)
     mainWindow.setSize(options.width!, options.height!)
@@ -189,9 +189,21 @@ function createMain() {
     // macos min size
     mainWindow.setMinimumSize(MIN_WINDOW_SIZE, MIN_WINDOW_SIZE)
 
+    mainWindow.show()
+    mainWindow.focus()
+
     if (RECORD_STARTUP_TIME) console.time("Main window content")
     loadWindowContent(mainWindow)
     setMainListeners()
+
+    if (!isProd) {
+        setTimeout(() => {
+            if (!isLoaded && mainWindow && !mainWindow.isDestroyed()) {
+                console.info("Dev fallback: Showing main window after timeout")
+                mainWindowLoaded()
+            }
+        }, 10000)
+    }
 
     if (RECORD_STARTUP_TIME) console.timeEnd("Main window")
 
@@ -204,16 +216,23 @@ function createMain() {
 
 let isLoaded = false
 function mainWindowLoaded() {
-    if (RECORD_STARTUP_TIME) console.timeEnd("Main window content")
-    isLoaded = true
+    try {
+        if (RECORD_STARTUP_TIME) console.timeEnd("Main window content")
+        isLoaded = true
 
-    mainWindowInitialize()
-    if (config.get("maximized")) maximizeMain()
+        mainWindowInitialize()
+        if (config.get("maximized")) maximizeMain()
 
-    mainWindow?.show()
-    loadingWindow?.close()
+        mainWindow?.show()
+        mainWindow?.focus()
+        loadingWindow?.close()
 
-    if (RECORD_STARTUP_TIME) console.timeEnd("Full startup")
+        if (RECORD_STARTUP_TIME) console.timeEnd("Full startup")
+    } catch (e) {
+        console.error("Error in mainWindowLoaded:", e)
+        mainWindow?.show()
+        mainWindow?.focus()
+    }
 }
 
 export async function loadWindowContent(window: BrowserWindow, type: null | "output" = null) {
@@ -223,12 +242,20 @@ export async function loadWindowContent(window: BrowserWindow, type: null | "out
     else {
         // load development environment
         if (mainOutput) openDevTools(window)
-        window.loadURL("http://localhost:3000").catch(loadingFailed)
+        window.loadURL("http://127.0.0.1:3000/index.html").catch(loadingFailed)
     }
 
     window.webContents.on("did-finish-load", () => {
         window.webContents.send(STARTUP, { channel: "TYPE", data: type, autoProfile })
     })
+
+    const getStartupType = (_event: Electron.IpcMainEvent, msg: any) => {
+        if (msg?.channel === "GET_TYPE" && !window.isDestroyed()) {
+            window.webContents.send(STARTUP, { channel: "TYPE", data: type, autoProfile })
+        }
+    }
+    ipcMain.on(STARTUP, getStartupType)
+    window.once("closed", () => ipcMain.removeListener(STARTUP, getStartupType))
 
     function loadingFailed(err: Error) {
         console.error("Failed to load window:", JSON.stringify(err))

--- a/src/electron/utils/windowOptions.ts
+++ b/src/electron/utils/windowOptions.ts
@@ -25,7 +25,7 @@ export const mainOptions: BrowserWindowConstructorOptions = {
     backgroundColor: "#242832",
     titleBarStyle: isMac ? "hidden" : "default",
     trafficLightPosition: { x: 10, y: 12 }, // mac buttons
-    show: false,
+    show: true,
     webPreferences: {
         preload: join(__dirname, "..", "preload"), // browser - node communication
         devTools: !isProd, // enable dev tools in dev

--- a/src/frontend/components/helpers/output.ts
+++ b/src/frontend/components/helpers/output.ts
@@ -8,7 +8,8 @@ import type { Resolution, Styles } from "../../../types/Settings"
 import type { Item, Layout, LayoutRef, Media, OutSlide, Show, Slide, SlideData, Template, TemplateSettings, Transition } from "../../../types/Show"
 import { AudioAnalyser } from "../../audio/audioAnalyser"
 import { requestMain, sendMain } from "../../IPC/main"
-import { actions, activeFocus, activeProject, activeRename, activeShow, activeTimers, allOutputs, categories, connections, currentOutputSettings, customMessageCredits, disabledServers, effects, focusMode, lockedOverlays, media, outputDisplay, outputs, outputSlideCache, outputState, overlays, overlayTimers, projects, scriptures, scriptureSettings, serverData, showsCache, special, stageShows, styles, templates, theme, themes, transitionData, usageLog } from "../../stores"
+import { actions, activeFocus, activeProject, activeRename, activeShow, activeTimers, allOutputs, categories, connections, currentOutputSettings, customMessageCredits, disabledServers, effects, focusMode, lockedOverlays, media, outputDisplay, outputs, outputSlideCache, outputState, overlays, overlayTimers, previewMode, projects, scriptures, scriptureSettings, serverData, showsCache, special, stageShows, styles, templates, theme, themes, transitionData, usageLog } from "../../stores"
+import { setPreview } from "./previewProgram"
 import { trackScriptureUsage } from "../../utils/analytics"
 import { isMainWindow, isOutputWindow, newToast } from "../../utils/common"
 import { translateText } from "../../utils/language"
@@ -57,6 +58,11 @@ export function toggleOutput(id: string) {
 // transition: null,
 let resetActionTrigger = false
 export function setOutput(type: string, data: any, toggle = false, outputId = "", add = false) {
+    if (get(previewMode) && type !== "transition" && type !== "refresh") {
+        setPreview(type, data, toggle, outputId, add)
+        return
+    }
+
     const ref = data?.layout ? _show(data.id).layouts([data.layout]).ref()[0] || [] : []
 
     // stop any active break slide recording when the slide changes

--- a/src/frontend/components/helpers/previewProgram.ts
+++ b/src/frontend/components/helpers/previewProgram.ts
@@ -1,0 +1,208 @@
+import { get } from "svelte/store"
+import type { OutData } from "../../../types/Output"
+import type { Transition } from "../../../types/Show"
+import { outputs, previewMode, previewOut, previewTransitionType, previewTransitionDuration, transitionData } from "../../stores"
+import { clone, removeDuplicates } from "./array"
+import { getActiveOutputs, setOutput } from "./output"
+import { _show } from "./shows"
+import { updateOut } from "./showActions"
+
+/**
+ * Load content into PREVIEW state (does NOT affect LED/Program output)
+ * Called instead of setOutput() when previewMode is enabled
+ */
+export function setPreview(type: string, data: any, toggle = false, outputId = "", add = false) {
+    const outs = outputId ? [outputId] : getActiveOutputs(get(outputs), true, false, true)
+
+    previewOut.update((a: any) => {
+        let toggleState = false
+        outs.forEach((id: string, i: number) => {
+            if (!a[id]) a[id] = {}
+
+            if (type === "overlays" || type === "effects") {
+                let outData: string[] = a[id][type] || []
+                let items = Array.isArray(data) ? data : data ? [data] : []
+                if (items.length) {
+                    if (toggle && i === 0) toggleState = outData.includes(items[0])
+                    if (toggle && toggleState) outData = outData.filter((x: any) => x !== items[0])
+                    else if (toggle || add) outData = removeDuplicates([...outData, ...items])
+                    else outData = items
+                } else {
+                    outData = []
+                }
+                a[id][type] = clone(outData)
+            } else {
+                a[id][type] = data ? clone(data) : null
+            }
+        })
+        return a
+    })
+}
+
+/**
+ * TAKE: Transfer preview content to program (LED)
+ * Copies previewOut state to outputs.out and triggers necessary side effects
+ */
+export function takeToProgram(outputId = "") {
+    if (!get(previewMode)) return
+
+    const preview = get(previewOut)
+    const outs = outputId ? [outputId] : getActiveOutputs(get(outputs), true, false, true)
+
+    outs.forEach((id: string) => {
+        const previewData = preview[id]
+        if (!previewData) return
+
+        if (previewData.background !== undefined) {
+            setOutputDirect("background", previewData.background, id)
+        }
+        if (previewData.slide !== undefined) {
+            setOutputDirect("slide", previewData.slide, id)
+            if (previewData.slide?.id && previewData.slide.index !== undefined) {
+                const ref = _show(previewData.slide.id).layouts([previewData.slide.layout]).ref()[0] || []
+                const wasPreviewMode = get(previewMode)
+                previewMode.set(false)
+                try {
+                    updateOut(previewData.slide.id, previewData.slide.index, ref, true, id)
+                } finally {
+                    if (wasPreviewMode) previewMode.set(true)
+                }
+            }
+        }
+        if (previewData.overlays !== undefined) {
+            setOutputDirect("overlays", previewData.overlays, id)
+        }
+        if (previewData.effects !== undefined) {
+            setOutputDirect("effects", previewData.effects, id)
+        }
+    })
+
+    // Clear preview after take
+    clearPreview(outputId)
+}
+
+/**
+ * FADE: Transfer preview to program with a fade transition
+ */
+export function fadeToProgram(customTransition?: Transition, outputId = "") {
+    if (!get(previewMode)) return
+
+    const duration = get(previewTransitionDuration) || 800
+    const currentTransition = clone(get(transitionData))
+
+    transitionData.set({
+        text: customTransition || { type: "fade", duration, easing: "sine" },
+        media: customTransition || { type: "fade", duration, easing: "sine" }
+    })
+
+    takeToProgram(outputId)
+
+    setTimeout(() => {
+        transitionData.set(currentTransition)
+    }, duration + 100)
+}
+
+/**
+ * CUT: Transfer preview to program instantly (no transition)
+ */
+export function cutToProgram(outputId = "") {
+    if (!get(previewMode)) return
+
+    const currentTransition = clone(get(transitionData))
+
+    transitionData.set({
+        text: { type: "none", duration: 0, easing: "" },
+        media: { type: "none", duration: 0, easing: "" }
+    })
+
+    takeToProgram(outputId)
+
+    setTimeout(() => {
+        transitionData.set(currentTransition)
+    }, 150)
+}
+
+/**
+ * Blackout live program output (Panic / Black button)
+ */
+export function blackoutProgram(outputId = "") {
+    const outs = outputId ? [outputId] : getActiveOutputs(get(outputs), true, false, true)
+    outs.forEach((id: string) => {
+        setOutputDirect("slide", null, id)
+        setOutputDirect("background", null, id)
+        setOutputDirect("overlays", [], id)
+        setOutputDirect("effects", [], id)
+    })
+}
+
+/**
+ * Swap preview and program content
+ */
+export function swapPreviewProgram(outputId = "") {
+    if (!get(previewMode)) return
+
+    const preview = get(previewOut)
+    const outs = outputId ? [outputId] : getActiveOutputs(get(outputs), true, false, true)
+
+    outs.forEach((id: string) => {
+        const currentProgram = clone(get(outputs)[id]?.out || {})
+        const currentPreview = clone(preview[id] || {})
+
+        previewOut.update((a: any) => {
+            a[id] = currentProgram
+            return a
+        })
+
+        if (currentPreview.slide !== undefined) setOutputDirect("slide", currentPreview.slide, id)
+        if (currentPreview.background !== undefined) setOutputDirect("background", currentPreview.background, id)
+        if (currentPreview.overlays !== undefined) setOutputDirect("overlays", currentPreview.overlays, id)
+        if (currentPreview.effects !== undefined) setOutputDirect("effects", currentPreview.effects, id)
+    })
+}
+
+/**
+ * Clear preview state
+ */
+export function clearPreview(outputId = "") {
+    if (outputId) {
+        previewOut.update((a: any) => {
+            delete a[outputId]
+            return a
+        })
+    } else {
+        previewOut.set({})
+    }
+}
+
+/**
+ * Quick action: load into preview + immediately take/fade to program
+ * Useful for SHIFT+F keyboard shortcuts
+ */
+export function quickTake(type: string, data: any, useFade = false) {
+    setPreview(type, data)
+    if (useFade) fadeToProgram()
+    else takeToProgram()
+}
+
+/**
+ * Toggle preview/program mode
+ */
+export function togglePreviewMode() {
+    previewMode.update((a: boolean) => !a)
+    if (!get(previewMode)) {
+        clearPreview()
+    }
+}
+
+/**
+ * Internal: directly call setOutput bypassing preview mode check
+ */
+export function setOutputDirect(type: string, data: any, outputId: string, toggle = false, add = false) {
+    const wasPreviewMode = get(previewMode)
+    previewMode.set(false)
+    try {
+        setOutput(type, data, toggle, outputId, add)
+    } finally {
+        if (wasPreviewMode) previewMode.set(true)
+    }
+}

--- a/src/frontend/components/helpers/showActions.ts
+++ b/src/frontend/components/helpers/showActions.ts
@@ -47,6 +47,7 @@ import {
     playingAudio,
     playingMetronome,
     playingVideoState,
+    previewMode,
     projects,
     projectTemplates,
     shows,
@@ -291,7 +292,7 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
 
     // trigger start show action first
     const startShowId = data.actions?.startShow?.id || data.actions?.slideActions?.find((a) => a && a.actionValues?.start_show)?.actionValues?.start_show?.id
-    if (startShowId) {
+    if (!get(previewMode) && startShowId) {
         startShow(startShowId)
         return
     }
@@ -316,7 +317,7 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
     // actions will only trigger on index 0 if multiple lines
     if (outputAtLine) {
         // restart any next slide timers
-        outputIds.map(nextSlideTimers)
+        if (!get(previewMode)) outputIds.map(nextSlideTimers)
         return
     }
 
@@ -353,7 +354,7 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
         }
 
         // nextTimer - start next slide timer immediately before any awaits
-        nextSlideTimers(outputId)
+        if (!get(previewMode)) nextSlideTimers(outputId)
 
         // background
         if (background && (isSlideBg || _show(showId).get("media")?.[background])) {
@@ -395,14 +396,14 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
         }
 
         // mics
-        if (data.mics) {
+        if (!get(previewMode) && data.mics) {
             data.mics.forEach((mic) => {
                 AudioMicrophone.start(mic.id, { name: mic.name })
             })
         }
 
         // audio
-        if (Array.isArray(data.audio)) {
+        if (!get(previewMode) && Array.isArray(data.audio)) {
             // let clear action trigger first
             setTimeout(() => {
                 data.audio?.forEach((audio: string) => {
@@ -438,7 +439,7 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
 
         // DEPRECATED since <= 1.1.6, but still in use
         // actions per output
-        if (data.actions) {
+        if (!get(previewMode) && data.actions) {
             if (data.actions.clearBackground) setOutput("background", null, false, outputId)
             if (data.actions.clearOverlays) clearOverlays(outputId)
         }
@@ -446,7 +447,7 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
 
     // actions
     // DEPRECATED since <= 1.1.6, but still in use
-    if (data.actions) {
+    if (!get(previewMode) && data.actions) {
         // clear first
         if (data.actions.stopTimers) stopTimers()
         if (data.actions.clearAudio) clearAudio()
@@ -459,12 +460,14 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
         if (data.actions.startTimer) playSlideTimers({ showId, slideId: layout[index].id, overlayIds: data.overlays || [] })
     }
 
-    if (data.actions?.slideActions?.length) {
-        // let values update
-        setTimeout(() => {
-            playSlideActions(data.actions!.slideActions!, outputIds, index)
-        }, actionTimeout)
-    } else playOutputStyleTemplateActions(outputIds)
+    if (!get(previewMode)) {
+        if (data.actions?.slideActions?.length) {
+            // let values update
+            setTimeout(() => {
+                playSlideActions(data.actions!.slideActions!, outputIds, index)
+            }, actionTimeout)
+        } else playOutputStyleTemplateActions(outputIds)
+    }
 
     function nextSlideTimers(outputId) {
         // clear any active slide timers

--- a/src/frontend/components/output/preview/MultiOutputs.svelte
+++ b/src/frontend/components/output/preview/MultiOutputs.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { activePage, activeStyle, audioChannelsData, dictionary, outputs, rtmpStatus, selected, settingsTab, styles, templates, toggleOutputEnabled } from "../../../stores"
+    import { activePage, activeStyle, audioChannelsData, dictionary, outputs, previewMode, previewOut, rtmpStatus, selected, settingsTab, styles, templates, toggleOutputEnabled } from "../../../stores"
     import { translateText } from "../../../utils/language"
     import AudioMeter from "../../drawer/audio/AudioMeter.svelte"
     import { openDrawer } from "../../edit/scripts/edit"
@@ -157,8 +157,27 @@ aria-label={fullscreen ? "Exit fullscreen preview" : "Toggle fullscreen preview"
         {@const isMuted = $audioChannelsData[`channel_${output.id}`]?.isMuted}
         {@const isNetworkOutput = output.ndi || output.webrtc || output.rtmp}
 
-        <div id={output.id} class="outputPreview output_button context #output_preview" class:drop-target={!fullscreen && dragOverOutputId === output.id} on:dragover={(e) => handleDragOver(e, output.id)} on:dragleave={(e) => handleDragLeave(e, output.id)} on:drop={(e) => handleDrop(e, output.id)} style={fullscreen ? (fullscreenId === output.id ? "display: contents;" : "opacity: 0;position: absolute;") : outs.length > 1 ? `border: 2px solid ${output?.color};width: 50%;` : "display: contents;"}>
-            <PreviewOutput outputId={output.id} {disableTransitions} disabled={outs.length > 1 && !fullscreen && !output?.active} {fullscreen} />
+        <div
+            id={output.id}
+            class="outputPreview output_button context #output_preview"
+            class:drop-target={!fullscreen && dragOverOutputId === output.id}
+            on:dragover={(e) => handleDragOver(e, output.id)}
+            on:dragleave={(e) => handleDragLeave(e, output.id)}
+            on:drop={(e) => handleDrop(e, output.id)}
+            style={fullscreen ? (fullscreenId === output.id ? "display: contents;" : "opacity: 0;position: absolute;") : outs.length > 1 && !$previewMode ? `border: 2px solid ${output?.color};width: 50%;` : "display: contents;"}
+        >
+            {#if $previewMode && !fullscreen}
+                <div class="pvw-pgm-container">
+                    <div class="pvw-screen">
+                        <PreviewOutput outputId={output.id} {disableTransitions} outOverride={$previewOut[output.id] || {}} badge="PREVIEW" />
+                    </div>
+                    <div class="pgm-screen">
+                        <PreviewOutput outputId={output.id} {disableTransitions} disabled={outs.length > 1 && !output?.active} badge="🔴 LIVE" />
+                    </div>
+                </div>
+            {:else}
+                <PreviewOutput outputId={output.id} {disableTransitions} disabled={outs.length > 1 && !fullscreen && !output?.active} {fullscreen} />
+            {/if}
 
             <!-- LIVE -->
             {#if !fullscreen && ((output.webrtcData?.url && output.webrtc) || (output.rtmp && hasStreamableDestination(output.rtmpData)))}
@@ -350,5 +369,34 @@ aria-label={fullscreen ? "Exit fullscreen preview" : "Toggle fullscreen preview"
         z-index: 5;
 
         opacity: 0.7;
+    }
+
+    /* PVW / PGM */
+    .pvw-pgm-container {
+        display: flex;
+        width: 100%;
+        height: 100%;
+        gap: 3px;
+        background-color: var(--primary-darkest);
+    }
+
+    .pvw-screen,
+    .pgm-screen {
+        flex: 1;
+        position: relative;
+        overflow: hidden;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 4px;
+        background-color: #000;
+    }
+
+    .pvw-screen {
+        border: 1px solid rgba(72, 203, 233, 0.4);
+    }
+
+    .pgm-screen {
+        border: 1px solid rgba(255, 71, 87, 0.4);
     }
 </style>

--- a/src/frontend/components/output/preview/Preview.svelte
+++ b/src/frontend/components/output/preview/Preview.svelte
@@ -26,6 +26,7 @@
     import ClearButtons from "./ClearButtons.svelte"
     import MultiOutputs from "./MultiOutputs.svelte"
     import PreviewOutputs from "./PreviewOutputs.svelte"
+    import PreviewProgramBar from "./PreviewProgramBar.svelte"
     import SpotifyController from "./SpotifyController.svelte"
 
     $: allActiveOutputs = getActiveOutputs($outputs, true, true, true)
@@ -262,6 +263,8 @@
                 <AudioMeter channelId="main" preview />
             </div>
         </div>
+
+        <PreviewProgramBar />
     {:else}
         <Button on:click={() => (enablePreview = true)} style="width: 100%;" center dark>
             <Icon id="eye" right />

--- a/src/frontend/components/output/preview/PreviewOutput.svelte
+++ b/src/frontend/components/output/preview/PreviewOutput.svelte
@@ -12,6 +12,8 @@
     export let disabled = false
     export let outputId = ""
     export let style = ""
+    export let outOverride: any = null
+    export let badge: string = ""
 
     $: resolution = getResolution(null, [$outputs, $styles], false, outputId)
     let width = 0
@@ -25,7 +27,13 @@
     {#if stageOutput}
         <StageLayout {outputId} stageId={stageOutput} preview={!disableTransitions} edit={false} />
     {:else}
-        <Output {outputId} style={getStyleResolution(resolution, fullscreen ? width : resolution.width, fullscreen ? height : resolution.height, "fit")} mirror preview={!disableTransitions} />
+        <Output {outputId} {outOverride} style={getStyleResolution(resolution, fullscreen ? width : resolution.width, fullscreen ? height : resolution.height, "fit")} mirror preview={!disableTransitions} />
+    {/if}
+
+    {#if badge}
+        <div class="badge" class:live={badge.includes("LIVE")}>
+            <span>{badge}</span>
+        </div>
     {/if}
 
     {#if !fullscreen && $livePrepare[outputId]}
@@ -36,6 +44,26 @@
 </div>
 
 <style>
+    .badge {
+        position: absolute;
+        top: 6px;
+        left: 6px;
+        padding: 2px 8px;
+        border-radius: 4px;
+        background-color: rgba(30, 30, 45, 0.85);
+        color: #48cbe9;
+        font-size: 0.75em;
+        font-weight: 700;
+        letter-spacing: 0.5px;
+        border: 1px solid rgba(72, 203, 233, 0.3);
+        pointer-events: none;
+        z-index: 5;
+    }
+    .badge.live {
+        color: #ff4757;
+        border-color: rgba(255, 71, 87, 0.4);
+        background-color: rgba(40, 10, 15, 0.85);
+    }
     .center {
         display: flex;
         align-items: center;

--- a/src/frontend/components/output/preview/PreviewProgramBar.svelte
+++ b/src/frontend/components/output/preview/PreviewProgramBar.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+    import { previewMode, previewOut, previewTransitionType } from "../../../stores"
+    import { takeToProgram, fadeToProgram, cutToProgram, togglePreviewMode } from "../../helpers/previewProgram"
+    import Button from "../../inputs/Button.svelte"
+    import T from "../../helpers/T.svelte"
+
+    $: hasPreviewContent = Object.keys($previewOut).length > 0
+</script>
+
+<div class="preview-program-bar" class:inactive={!$previewMode}>
+    {#if $previewMode}
+        <div class="transition-buttons">
+            <button class="action-btn cut" class:active={$previewTransitionType === "cut"} on:click={cutToProgram} disabled={!hasPreviewContent} title="Cut (instant switch) [F5]"> CUT </button>
+            <button class="action-btn fade" class:active={$previewTransitionType === "fade"} on:click={() => fadeToProgram()} disabled={!hasPreviewContent} title="Fade transition [F6]"> FADE </button>
+        </div>
+
+        <button class="action-btn take" on:click={() => takeToProgram()} disabled={!hasPreviewContent} title="Take preview to program [SPACE]"> TAKE </button>
+    {/if}
+
+    <div class="mode-toggle" class:standalone={!$previewMode}>
+        <button class="action-btn mode" class:active={$previewMode} on:click={togglePreviewMode} title={$previewMode ? "Disable Preview/Program mode (direct output)" : "Enable Preview/Program mode (vMix workflow)"}>
+            {$previewMode ? "PVW/PGM ON" : "⇄ PVW/PGM"}
+        </button>
+    </div>
+</div>
+
+<style>
+    .preview-program-bar {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        padding: 4px 8px;
+        background-color: var(--primary-darkest);
+        border-top: 1px solid var(--primary-lighter);
+    }
+
+    .preview-program-bar.inactive {
+        padding: 2px 8px;
+        justify-content: flex-end;
+        background-color: transparent;
+        border-top: none;
+    }
+
+    .transition-buttons {
+        display: flex;
+        gap: 2px;
+    }
+
+    .action-btn {
+        border: 1px solid var(--primary-lighter);
+        background-color: var(--primary-darker);
+        color: var(--text);
+        padding: 6px 14px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 0.85em;
+        font-weight: 600;
+        letter-spacing: 0.5px;
+        transition:
+            background-color 0.15s,
+            border-color 0.15s;
+        white-space: nowrap;
+    }
+
+    .action-btn:hover:not(:disabled) {
+        background-color: var(--primary);
+    }
+
+    .action-btn:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    .action-btn.cut {
+        color: #ff6b6b;
+        border-color: #ff6b6b40;
+    }
+    .action-btn.cut:hover:not(:disabled) {
+        background-color: #ff6b6b30;
+    }
+
+    .action-btn.fade {
+        color: #ffd93d;
+        border-color: #ffd93d40;
+    }
+    .action-btn.fade:hover:not(:disabled) {
+        background-color: #ffd93d30;
+    }
+
+    .action-btn.take {
+        flex: 1;
+        padding: 8px 20px;
+        font-size: 1em;
+        background-color: #c0392b;
+        color: white;
+        border-color: #e74c3c;
+    }
+    .action-btn.take:hover:not(:disabled) {
+        background-color: #e74c3c;
+    }
+    .action-btn.take:disabled {
+        background-color: #5a2d2d;
+        border-color: #7a3d3d;
+    }
+
+    .action-btn.mode {
+        font-size: 0.75em;
+        padding: 4px 8px;
+        color: #6dff85;
+        border-color: #6dff8540;
+    }
+    .action-btn.mode.active {
+        background-color: #6dff8520;
+    }
+    .action-btn.mode:hover {
+        background-color: #6dff8530;
+    }
+
+    .mode-toggle {
+        margin-left: auto;
+    }
+</style>

--- a/src/frontend/components/settings/tabs/OutputsGeneral.svelte
+++ b/src/frontend/components/settings/tabs/OutputsGeneral.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { autoOutput, os, special } from "../../../stores"
+    import { autoOutput, os, previewMode, special } from "../../../stores"
     import MaterialToggleSwitch from "../../inputs/MaterialToggleSwitch.svelte"
     import Tip from "../../main/Tip.svelte"
 
@@ -16,6 +16,7 @@
 <Tip type="info" value="tips.global_options" bottom={20} />
 
 <MaterialToggleSwitch label="settings.auto_output" checked={$autoOutput} defaultValue={false} on:change={(e) => autoOutput.set(e.detail)} />
+<MaterialToggleSwitch label="Preview / Program mode (vMix workflow)" checked={$previewMode} defaultValue={false} on:change={(e) => previewMode.set(e.detail)} />
 <!-- apparently doesn't work on some versions of macOS -->
 {#if $os.platform !== "darwin" || $special.hideCursor}
     <MaterialToggleSwitch label="settings.hide_cursor_in_output" checked={$special.hideCursor} defaultValue={false} on:change={(e) => updateSpecial(e.detail, "hideCursor")} />

--- a/src/frontend/stores.ts
+++ b/src/frontend/stores.ts
@@ -143,6 +143,12 @@ export const presentationData: Writable<any> = writable({})
 export const presentationApps: Writable<null | string[]> = writable(null)
 export const colorbars: Writable<{ [key: string]: string }> = writable({})
 export const livePrepare: Writable<{ [key: string]: boolean }> = writable({})
+
+// PREVIEW/PROGRAM MODE
+export const previewMode: Writable<boolean> = writable(false)
+export const previewOut: Writable<{ [outputId: string]: any }> = writable({})
+export const previewTransitionType: Writable<"cut" | "fade"> = writable("fade")
+export const previewTransitionDuration: Writable<number> = writable(800)
 export const overlayTimers: Writable<{ [key: string]: { outputId: string; overlayId: string; timer: NodeJS.Timeout } }> = writable({})
 export const slideTimelineSpeedMultiplier: Writable<number> = writable(1)
 
@@ -479,7 +485,10 @@ export const $ = {
     maxConnections,
     remotePassword,
     providerConnections,
-    calendars
+    calendars,
+    previewMode,
+    previewTransitionType,
+    previewTransitionDuration
 }
 
 // DEBUG STORE UPDATES

--- a/src/frontend/utils/shortcuts.ts
+++ b/src/frontend/utils/shortcuts.ts
@@ -21,7 +21,8 @@ import { importFromClipboard } from "../converters/importHelpers"
 import { addSection } from "../converters/project"
 import { requestMain, sendMain } from "../IPC/main"
 import { changeSlidesView } from "../show/slides"
-import { activeDrawerTab, activeEdit, activeFocus, activePage, activePopup, activeProject, activeStage, alertMessage, audioChannelsData, contextActive, drawer, editMode, focusedArea, focusMode, guideActive, media, os, outLocked, outputs, playingVideoState, projects, quickSearchActive, refreshEditSlide, selected, showRecentlyUsedProjects, special, spellcheck, styles, timelineRecordingAction, topContextActive } from "../stores"
+import { activeDrawerTab, activeEdit, activeFocus, activePage, activePopup, activeProject, activeStage, alertMessage, audioChannelsData, contextActive, drawer, editMode, focusedArea, focusMode, guideActive, media, os, outLocked, outputs, playingVideoState, previewMode, projects, quickSearchActive, refreshEditSlide, selected, showRecentlyUsedProjects, special, spellcheck, styles, timelineRecordingAction, topContextActive } from "../stores"
+import { takeToProgram, fadeToProgram, cutToProgram, blackoutProgram } from "../components/helpers/previewProgram"
 import { audioExtensions, imageExtensions, videoExtensions } from "../values/extensions"
 import { drawerTabs } from "../values/tabs"
 import { activeShow } from "./../stores"
@@ -365,8 +366,40 @@ export const previewShortcuts = {
         timelineRecordingAction.set({ id: "clear_audio" })
     },
     F5: () => {
+        if (get(previewMode)) {
+            cutToProgram()
+            return
+        }
         if (!presentationControllersKeysDisabled()) OutputHelper.advanceOutputs()
         else setOutput("transition", null)
+    },
+    F6: () => {
+        if (get(previewMode)) {
+            fadeToProgram()
+            return
+        }
+    },
+    b: () => {
+        if (get(previewMode)) {
+            blackoutProgram()
+            return true
+        }
+        return false
+    },
+    B: () => {
+        if (get(previewMode)) {
+            blackoutProgram()
+            return true
+        }
+        return false
+    },
+    Enter: (e: any) => {
+        if (get(previewMode)) {
+            e?.preventDefault?.()
+            fadeToProgram()
+            return true
+        }
+        return false
     },
 
     " ": (e: KeyboardEvent) => {
@@ -376,6 +409,10 @@ export const previewShortcuts = {
         if (isTimelineActive()) return
 
         e.preventDefault()
+        if (get(previewMode)) {
+            takeToProgram()
+            return
+        }
         OutputHelper.advanceOutputs(e)
     },
     ArrowRight: (e: any) => {

--- a/src/frontend/utils/startup.ts
+++ b/src/frontend/utils/startup.ts
@@ -52,6 +52,9 @@ export async function startup() {
         },
         "startup"
     )
+
+    // In case did-finish-load already fired before listener was registered
+    window.api.send(STARTUP, { channel: "GET_TYPE" })
 }
 
 async function startupMain() {

--- a/src/types/Output.ts
+++ b/src/types/Output.ts
@@ -69,6 +69,13 @@ export interface OutData {
     transition?: null | OutTransition
 }
 
+// Preview/Program mode data - reuses OutData structure
+export interface PreviewData extends OutData {
+    showId?: string // show ID being previewed
+    showName?: string // for UI display
+    timestamp?: number // when loaded, used for preload priority
+}
+
 export interface Animation {
     actions: AnimationAction[]
     repeat?: boolean

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -4,6 +4,7 @@ import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte"
 const production = process.env.NODE_ENV === "production"
 
 export default defineConfig({
+    appType: "spa",
     plugins: [
         svelte({
             preprocess: vitePreprocess(),


### PR DESCRIPTION
## Description
This PR introduces a **Preview / Program (PVW / PGM)** workflow (similar to vMix, OBS Studio Mode, and professional broadcast switchers) to FreeShow.

It allows operators to cue up and preview slides, backgrounds, media, overlays, and templates in a dedicated Preview bus without immediately affecting what is being projected live to the LED screen / Program output. When ready, the operator can transition content seamlessly to Program via Cut, Fade, or Take controls.

### Key Features
1. **Separate Preview / Program Bus**:
   - Selecting any slide, background, or overlay when in PVW/PGM mode stages it into the Preview state.
   - The Program output (and physical LED / NDI / Blackmagic screens) continues showing current live content unaffected.
2. **Side-by-Side Dual Monitor View**:
   - The output monitor section automatically splits into two side-by-side monitors: \[PREVIEW]\ (left) and \[🔴 LIVE]\ (right).
3. **Transition Controls (PreviewProgramBar)**:
   - **TAKE** (\SPACE\): Instantly takes the prepared Preview content live to Program.
   - **FADE** (\ENTER\ / \F6\): Performs a smooth crossfade transition from Preview to Program.
   - **CUT** (\F5\): Performs an instant cut transition without delay.
   - **BLACK** (\B\): Instant blackout panic button to clear the Program screen.
4. **Deferred Action / Audio Execution**:
   - Slide timers, audio tracks, and action triggers attached to slides are deferred until the content is taken live to Program.
5. **100% Backward Compatible**:
   - Default is \previewMode = false\, preserving existing 1-bus direct-to-output behavior.
   - Toggle button \⇄ PVW/PGM\ available on the preview bar and in Settings (General Outputs).