### PR TITLE
Scripture undertitles wrap on the output instead of being clipped

### DIFF
--- a/src/common/scripture/sanitizeVerseText.ts
+++ b/src/common/scripture/sanitizeVerseText.ts
@@ -1,6 +1,7 @@
 const BR_TAG_REGEX = /<\s*br\s*\/?>/gi
 const NBSP_REGEX = /\u00a0/g
 const QUOTES_REGEX = /<q>(.*?)<\/q>/g
+const UNDERTITLE_REGEX = /<h4[^>]*>(.*?)<\/h4>/g
 const MULTIPLE_SPACES_REGEX = / {2,}/g
 
 export function sanitizeVerseText(input: unknown): string {
@@ -10,5 +11,6 @@ export function sanitizeVerseText(input: unknown): string {
     const withoutBreaks = text.replace(BR_TAG_REGEX, " ")
     const normalizedSpaces = withoutBreaks.replace(NBSP_REGEX, " ")
     const withQuotes = normalizedSpaces.replace(QUOTES_REGEX, "“$1”")
-    return withQuotes.replace(MULTIPLE_SPACES_REGEX, " ").trim()
+    const withUndertitles = withQuotes.replace(UNDERTITLE_REGEX, '<span class="undertitle">$1</span>')
+    return withUndertitles.replace(MULTIPLE_SPACES_REGEX, " ").trim()
 }

--- a/src/common/scripture/sanitizeVerseText.ts
+++ b/src/common/scripture/sanitizeVerseText.ts
@@ -1,7 +1,7 @@
 const BR_TAG_REGEX = /<\s*br\s*\/?>/gi
 const NBSP_REGEX = /\u00a0/g
 const QUOTES_REGEX = /<q>(.*?)<\/q>/g
-const UNDERTITLE_REGEX = /<h4[^>]*>(.*?)<\/h4>/g
+const UNDERTITLE_REGEX = /<h4[^>]*>(.*?)<\/h4>\s*/g
 const MULTIPLE_SPACES_REGEX = / {2,}/g
 
 export function sanitizeVerseText(input: unknown): string {
@@ -11,6 +11,6 @@ export function sanitizeVerseText(input: unknown): string {
     const withoutBreaks = text.replace(BR_TAG_REGEX, " ")
     const normalizedSpaces = withoutBreaks.replace(NBSP_REGEX, " ")
     const withQuotes = normalizedSpaces.replace(QUOTES_REGEX, "“$1”")
-    const withUndertitles = withQuotes.replace(UNDERTITLE_REGEX, '<span class="undertitle">$1</span>')
+    const withUndertitles = withQuotes.replace(UNDERTITLE_REGEX, '<span class="undertitle">$1 </span>')
     return withUndertitles.replace(MULTIPLE_SPACES_REGEX, " ").trim()
 }

--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -1392,6 +1392,16 @@
         font-size: 0.8em;
         font-style: italic;
     }
+    /* clip keeps the text baseline, hidden would align the box bottom */
+    .main span.verse :global(span.undertitle) {
+        display: inline-block;
+        max-width: 35%;
+        overflow: clip;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--secondary);
+        font-weight: 600;
+    }
 
     /* LIST MODE */
 

--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -1398,7 +1398,7 @@
         max-width: 35%;
         overflow: clip;
         text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: pre;
         color: var(--secondary);
         font-weight: 600;
     }

--- a/src/frontend/components/slide/TextboxLines.svelte
+++ b/src/frontend/components/slide/TextboxLines.svelte
@@ -573,6 +573,13 @@
         font-size: 0.8em;
         font-style: italic;
     }
+    /* a block here would give the line's leading space its own line */
+    .break :global(span.undertitle) {
+        display: inline-block;
+        width: 100%;
+        color: var(--secondary);
+        font-weight: 600;
+    }
 
     /* .height {
         height: 1em;


### PR DESCRIPTION
Fixes #3707

- `json-bible` renders `# title #` as `<h4>`, and the global `h1–h6` rule (nowrap + ellipsis) reaches the output textbox, so Psalm titles longer than one line end in "…".
- `sanitizeVerseText` now turns that `<h4>` into `<span class="undertitle">`. Every drawer/output verse already passes through it.
- Output (`TextboxLines.svelte`): the span is `display: block` with the same colour and weight the heading had, and wraps like the verse text.
- Drawer verse list (`Scripture.svelte`): the title is truncated after ~35% of the row so number, title and text stay on one row.

Not included: the optional "Titles" colour setting mentioned in the issue. Can be a follow-up if wanted.
