### PR TITLE
Scripture titles can be hidden or recoloured

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1568,6 +1568,7 @@
         "first_slide_reference": "Reference on first slide",
         "reference_at_bottom": "Move to bottom",
         "red_jesus": "Jesus words in red",
+        "titles": "Titles",
         "show_all": "Show all",
         "search": "Search in the Bible"
     },

--- a/src/common/scripture/sanitizeVerseText.ts
+++ b/src/common/scripture/sanitizeVerseText.ts
@@ -1,6 +1,7 @@
 const BR_TAG_REGEX = /<\s*br\s*\/?>/gi
 const NBSP_REGEX = /\u00a0/g
 const QUOTES_REGEX = /<q>(.*?)<\/q>/g
+const UNDERTITLE_REGEX = /<h4[^>]*>(.*?)<\/h4>/g
 const MULTIPLE_SPACES_REGEX = / {2,}/g
 
 export function sanitizeVerseText(input: unknown): string {
@@ -10,5 +11,6 @@ export function sanitizeVerseText(input: unknown): string {
     const withoutBreaks = text.replace(BR_TAG_REGEX, " ")
     const normalizedSpaces = withoutBreaks.replace(NBSP_REGEX, " ")
     const withQuotes = normalizedSpaces.replace(QUOTES_REGEX, "“$1”")
-    return withQuotes.replace(MULTIPLE_SPACES_REGEX, " ").trim()
+    const withUndertitles = withQuotes.replace(UNDERTITLE_REGEX, '<span class="undertitle">$1</span>')
+    return withUndertitles.replace(MULTIPLE_SPACES_REGEX, " ").trim()
 }

--- a/src/common/scripture/sanitizeVerseText.ts
+++ b/src/common/scripture/sanitizeVerseText.ts
@@ -1,7 +1,7 @@
 const BR_TAG_REGEX = /<\s*br\s*\/?>/gi
 const NBSP_REGEX = /\u00a0/g
 const QUOTES_REGEX = /<q>(.*?)<\/q>/g
-const UNDERTITLE_REGEX = /<h4[^>]*>(.*?)<\/h4>/g
+const UNDERTITLE_REGEX = /<h4[^>]*>(.*?)<\/h4>\s*/g
 const MULTIPLE_SPACES_REGEX = / {2,}/g
 
 export function sanitizeVerseText(input: unknown): string {
@@ -11,6 +11,6 @@ export function sanitizeVerseText(input: unknown): string {
     const withoutBreaks = text.replace(BR_TAG_REGEX, " ")
     const normalizedSpaces = withoutBreaks.replace(NBSP_REGEX, " ")
     const withQuotes = normalizedSpaces.replace(QUOTES_REGEX, "“$1”")
-    const withUndertitles = withQuotes.replace(UNDERTITLE_REGEX, '<span class="undertitle">$1</span>')
+    const withUndertitles = withQuotes.replace(UNDERTITLE_REGEX, '<span class="undertitle">$1 </span>')
     return withUndertitles.replace(MULTIPLE_SPACES_REGEX, " ").trim()
 }

--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -1392,6 +1392,16 @@
         font-size: 0.8em;
         font-style: italic;
     }
+    /* clip keeps the text baseline, hidden would align the box bottom */
+    .main span.verse :global(span.undertitle) {
+        display: inline-block;
+        max-width: 35%;
+        overflow: clip;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        color: var(--secondary);
+        font-weight: 600;
+    }
 
     /* LIST MODE */
 

--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -1398,7 +1398,7 @@
         max-width: 35%;
         overflow: clip;
         text-overflow: ellipsis;
-        white-space: nowrap;
+        white-space: pre;
         color: var(--secondary);
         font-weight: 600;
     }

--- a/src/frontend/components/drawer/bible/scripture.ts
+++ b/src/frontend/components/drawer/bible/scripture.ts
@@ -1697,7 +1697,8 @@ function removeTags(text: string) {
     return text.replace(/(<([^>]+)>)/gi, "")
 }
 
-const UNDERTITLE_REGEX = /<span class="undertitle">(.*?)<\/span>/g
+// stripMarkdown removes the quotes around attribute values
+const UNDERTITLE_REGEX = /<span class="?undertitle"?>(.*?)<\/span>/g
 
 function colorUndertitles(text: string) {
     const color = get(scriptureSettings).undertitleColor
@@ -1707,9 +1708,10 @@ function colorUndertitles(text: string) {
 
 export function formatBibleText(text: string | undefined, redJesus = false) {
     if (!text) return ""
-    text = colorUndertitles(sanitizeVerseText(text))
+    text = sanitizeVerseText(text)
     if (redJesus) text = text.replace(/!\{(.*?)\}!/g, '<span class="wj">$1</span>')
-    return stripMarkdown(text).replaceAll("/ ", " ").replaceAll("*", "").replaceAll("&amp;", "&")
+    text = stripMarkdown(text).replaceAll("/ ", " ").replaceAll("*", "").replaceAll("&amp;", "&")
+    return colorUndertitles(text)
 }
 
 // CREATE SHOW/SLIDES

--- a/src/frontend/components/drawer/bible/scripture.ts
+++ b/src/frontend/components/drawer/bible/scripture.ts
@@ -926,6 +926,7 @@ export async function getScriptureSlidesNew(data: any, onlyOne = false, disableR
                     text = text.replace(/<span class="wj" ?>(.*?)<\/span>/g, "!{$1}!")
                     text = text.replace(/<red ?>(.*?)<\/red>/g, "!{$1}!")
                     text = text.replace(/<span style="color:red;" ?>(.*?)<\/span>/g, "!{$1}!")
+                    if (get(scriptureSettings).undertitles === false) text = text.replace(UNDERTITLE_REGEX, "")
 
                     if (verseNumbers) {
                         const { id, subverse, endNumber } = getVerseIdParts(v)
@@ -1227,6 +1228,7 @@ export function getScriptureSlides({ biblesContent, selectedChapters, selectedVe
             // custom Jesus red to JSON format: !{}!
             text = text.replace(/<span class="wj" ?>(.*?)<\/span>/g, "!{$1}!")
             text = text.replace(/<red ?>(.*?)<\/red>/g, "!{$1}!")
+            if (get(scriptureSettings).undertitles === false) text = text.replace(UNDERTITLE_REGEX, "")
 
             // highlight Jesus text
             const textArray: any[] = []
@@ -1695,9 +1697,17 @@ function removeTags(text: string) {
     return text.replace(/(<([^>]+)>)/gi, "")
 }
 
+const UNDERTITLE_REGEX = /<span class="undertitle">(.*?)<\/span>/g
+
+function colorUndertitles(text: string) {
+    const color = get(scriptureSettings).undertitleColor
+    if (!color) return text
+    return text.replace(UNDERTITLE_REGEX, `<span class="undertitle" style="color: ${color};">$1</span>`)
+}
+
 export function formatBibleText(text: string | undefined, redJesus = false) {
     if (!text) return ""
-    text = sanitizeVerseText(text)
+    text = colorUndertitles(sanitizeVerseText(text))
     if (redJesus) text = text.replace(/!\{(.*?)\}!/g, '<span class="wj">$1</span>')
     return stripMarkdown(text).replaceAll("/ ", " ").replaceAll("*", "").replaceAll("&amp;", "&")
 }

--- a/src/frontend/components/drawer/info/ScriptureInfo.svelte
+++ b/src/frontend/components/drawer/info/ScriptureInfo.svelte
@@ -2,7 +2,7 @@
     import type { MediaStyle } from "../../../../types/Main"
     import type { BibleContent } from "../../../../types/Scripture"
     import type { Item } from "../../../../types/Show"
-    import { activeEdit, activePage, activeScripture, activeStyle, drawerTabsData, media, outputs, scriptureSettings, settingsTab, styles, templates } from "../../../stores"
+    import { activeEdit, activePage, activeScripture, activeStyle, drawerTabsData, media, outputs, scriptureSettings, settingsTab, styles, templates, theme, themes } from "../../../stores"
     import { setDefaultScriptureTemplates } from "../../../utils/createData"
     import { confirmCustom } from "../../../utils/popup"
     import { mediaExtensions } from "../../../values/extensions"
@@ -140,6 +140,8 @@
     }
 
     $: containsJesusWords = Object.values(biblesContent?.[0]?.verses?.[0] || {})?.find((text: any) => text?.includes('<span class="wj"') || text?.includes("<red") || text?.includes("color:red;") || text?.includes("!{"))
+    $: containsUndertitles = Object.values(biblesContent?.[0]?.verses?.[0] || {})?.find((text: any) => text?.includes('class="undertitle"'))
+    $: secondaryColor = $themes[$theme]?.colors?.secondary || "#F0008C"
 
     $: previousSlides = "{}"
     let currentOutputSlides: any[] = []
@@ -243,6 +245,14 @@
                 <MaterialToggleSwitch label="scripture.red_jesus" style="width: 100%;" checked={$scriptureSettings.redJesus} defaultValue={false} on:change={(e) => update("redJesus", e.detail)} />
                 <!-- DEPRECATED -->
                 <MaterialColorInput label="edit.color" value={$scriptureSettings.jesusColor || "#FF4136"} defaultValue="#FF4136" on:change={(e) => update("jesusColor", e.detail)} />
+            {/if}
+
+            <!-- Undertitles -->
+            {#if containsUndertitles || $scriptureSettings.undertitles === false}
+                <MaterialToggleSwitch label="scripture.titles" style="width: 100%;" checked={$scriptureSettings.undertitles !== false} defaultValue={true} on:change={(e) => update("undertitles", e.detail)} />
+                {#if $scriptureSettings.undertitles !== false}
+                    <MaterialColorInput label="edit.color" value={$scriptureSettings.undertitleColor || secondaryColor} defaultValue={secondaryColor} on:change={(e) => update("undertitleColor", e.detail)} />
+                {/if}
             {/if}
 
             <!-- Smart split -->

--- a/src/frontend/components/drawer/info/ScriptureInfo.svelte
+++ b/src/frontend/components/drawer/info/ScriptureInfo.svelte
@@ -2,7 +2,7 @@
     import type { MediaStyle } from "../../../../types/Main"
     import type { BibleContent } from "../../../../types/Scripture"
     import type { Item } from "../../../../types/Show"
-    import { activeEdit, activePage, activeScripture, activeStyle, drawerTabsData, media, outputs, scriptureSettings, settingsTab, styles, templates, theme, themes } from "../../../stores"
+    import { activeEdit, activePage, activeScripture, activeStyle, drawerTabsData, media, outputs, scriptureSettings, settingsTab, styles, templates } from "../../../stores"
     import { setDefaultScriptureTemplates } from "../../../utils/createData"
     import { confirmCustom } from "../../../utils/popup"
     import { mediaExtensions } from "../../../values/extensions"
@@ -141,7 +141,7 @@
 
     $: containsJesusWords = Object.values(biblesContent?.[0]?.verses?.[0] || {})?.find((text: any) => text?.includes('<span class="wj"') || text?.includes("<red") || text?.includes("color:red;") || text?.includes("!{"))
     $: containsUndertitles = Object.values(biblesContent?.[0]?.verses?.[0] || {})?.find((text: any) => text?.includes('class="undertitle"'))
-    $: secondaryColor = $themes[$theme]?.colors?.secondary || "#F0008C"
+    const secondaryColor = getComputedStyle(document.documentElement).getPropertyValue("--secondary").trim() || "#F0008C"
 
     $: previousSlides = "{}"
     let currentOutputSlides: any[] = []

--- a/src/frontend/components/slide/TextboxLines.svelte
+++ b/src/frontend/components/slide/TextboxLines.svelte
@@ -573,6 +573,13 @@
         font-size: 0.8em;
         font-style: italic;
     }
+    /* a block here would give the line's leading space its own line */
+    .break :global(span.undertitle) {
+        display: inline-block;
+        width: 100%;
+        color: var(--secondary);
+        font-weight: 600;
+    }
 
     /* .height {
         height: 1em;


### PR DESCRIPTION
Follows up on #3711 as discussed there: a `{scripture_undertitle}` placeholder, handled like `{scripture_red_jesus}`.

- Put `{scripture_undertitle}` in a scripture template and give it a style; the placeholder is removed from the slide and its style goes onto the title span (`.undertitle`, from #3708).
- A px font size in the template becomes a share of the verse text size, so titles scale with auto size (60px next to 100px text renders at 60%).
- Templates without the placeholder are unchanged: the title keeps the theme's secondary colour and semibold weight from the stylesheet.
- Listed under the scripture dynamic values so it can be inserted from the editor.

Verified in an isolated build with a 60px orange italic placeholder next to 100px text: the title renders orange, italic, at 60% of the verse size, on its own line as before.
