### PR TITLE
Bracketed text keeps its template style inside red-letter verses

### DIFF
--- a/src/frontend/components/drawer/bible/scripture.ts
+++ b/src/frontend/components/drawer/bible/scripture.ts
@@ -1699,7 +1699,11 @@ export function formatBibleText(text: string | undefined, redJesus = false) {
     if (!text) return ""
     text = sanitizeVerseText(text)
     if (redJesus) text = text.replace(/!\{(.*?)\}!/g, '<span class="wj">$1</span>')
-    return stripMarkdown(text).replaceAll("/ ", " ").replaceAll("*", "").replaceAll("&amp;", "&")
+    // stripMarkdown pairs straight quotes, keep it away from the ones around attribute values
+    text = tokenizeHtml(text)
+        .map((token) => (token.type === "tag" ? token.value : stripMarkdown(token.value)))
+        .join("")
+    return text.replaceAll("/ ", " ").replaceAll("*", "").replaceAll("&amp;", "&")
 }
 
 // CREATE SHOW/SLIDES

--- a/src/frontend/components/slide/wordOverride.ts
+++ b/src/frontend/components/slide/wordOverride.ts
@@ -49,7 +49,8 @@ function buildOverrideRegex(override: TemplateStyleOverride) {
 
 function splitSegment(segment: any, regex: RegExp, override: TemplateStyleOverride) {
     if (!segment?.value) return [segment]
-    if (segment.customType?.includes("disableTemplate")) return [segment]
+    // verse numbers keep their own style, red-letter runs are still split
+    if (segment.customType === "disableTemplate") return [segment]
 
     const text = String(segment.value)
     const matcher = new RegExp(regex.source, regex.flags)

--- a/src/frontend/components/slide/wordOverride.ts
+++ b/src/frontend/components/slide/wordOverride.ts
@@ -49,8 +49,7 @@ function buildOverrideRegex(override: TemplateStyleOverride) {
 
 function splitSegment(segment: any, regex: RegExp, override: TemplateStyleOverride) {
     if (!segment?.value) return [segment]
-    // verse numbers keep their own style, red-letter runs are still split
-    if (segment.customType === "disableTemplate") return [segment]
+    if (segment.customType?.includes("disableTemplate")) return [segment]
 
     const text = String(segment.value)
     const matcher = new RegExp(regex.source, regex.flags)


### PR DESCRIPTION
Fixes #3710

- `splitSegment` skipped every `disableTemplate*` segment, so the Brackets style overwrite never reached bracketed text inside red-letter runs. Only verse numbers keep the exemption now; `disableTemplate_jw` runs are split like any other text and the override style is merged on top of the red colour.
- `formatBibleText` applied `stripMarkdown` to rendered HTML. Its quote rule pairs straight quotes across tags, so with AMP's unmatched opening quotes the last `class="uncertain"` came out as `class=uncertain"`. Markdown is now stripped from the text between tags only, using the existing `tokenizeHtml`.

Touches the same lines of `formatBibleText` as #3709 and #3711; whichever lands second needs a trivial rebase.
