### PR TITLE
Fix ppt PPT text tag <a:r err=1 /> causes line break

### DIFF
--- a/src/frontend/converters/powerpoint/PowerPointHelper.ts
+++ b/src/frontend/converters/powerpoint/PowerPointHelper.ts
@@ -15,6 +15,7 @@ import type { Item, Line } from "../../../types/Show"
 import { getItemText } from "../../components/edit/scripts/textStyle"
 import { clone } from "../../components/helpers/array"
 import { hexToHSL, hexToRgb, hslToHex } from "../../components/helpers/color"
+import { mergeAdjacentTextRuns } from "./powerpointTextRuns"
 import { getCustomShapePath, getPresetShapePath } from "./powerpointShapes"
 
 export interface Relationship {
@@ -806,6 +807,8 @@ export class PowerPointPackage {
                                 }
                             ] // space so style (font size) applies
                           : []
+
+                    text = mergeAdjacentTextRuns(text)
 
                     if (text.length && bullet) {
                         text = [autoNum ? { ...bullet, value: getBulletValue(autoNum, bulletNum + startAt - 1) } : bullet, ...text]

--- a/src/frontend/converters/powerpoint/powerpointImporter.test.ts
+++ b/src/frontend/converters/powerpoint/powerpointImporter.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest"
+import { mergeAdjacentTextRuns } from "./powerpointTextRuns"
+
+describe("PowerPoint run merging", () => {
+    it("merges adjacent same-style runs but preserves explicit line breaks", () => {
+        const runs = [
+            { value: "err=", style: "color: #000000; font-size: 24px;" },
+            { value: "1", style: "color: #000000; font-size: 24px;" },
+            { value: "<br>", style: "color: #000000; font-size: 24px;" },
+            { value: "next", style: "color: #000000; font-size: 24px;" },
+            { value: " line", style: "color: #ff0000; font-size: 24px;" }
+        ]
+
+        expect(mergeAdjacentTextRuns(runs)).toEqual([
+            { value: "err=1", style: "color: #000000; font-size: 24px;" },
+            { value: "<br>", style: "color: #000000; font-size: 24px;" },
+            { value: "next", style: "color: #000000; font-size: 24px;" },
+            { value: " line", style: "color: #ff0000; font-size: 24px;" }
+        ])
+    })
+})

--- a/src/frontend/converters/powerpoint/powerpointTextRuns.ts
+++ b/src/frontend/converters/powerpoint/powerpointTextRuns.ts
@@ -1,0 +1,43 @@
+export type PowerPointTextRun = {
+    value?: string
+    style?: string
+    customType?: string
+    sourceDynamicKey?: string
+}
+
+function normalizeMetadata(run: PowerPointTextRun) {
+    return `${run.customType || ""}|${run.sourceDynamicKey || ""}`
+}
+
+export function mergeAdjacentTextRuns<T extends PowerPointTextRun>(runs: T[]): T[] {
+    if (!Array.isArray(runs) || runs.length < 2) return runs
+
+    const merged: T[] = []
+
+    for (const run of runs) {
+        if (typeof run?.value !== "string") {
+            merged.push(run)
+            continue
+        }
+
+        const previous = merged.at(-1)
+        const hasExplicitBreak = run.value.includes("<br>") || run.value.includes("\n")
+
+        if (
+            previous &&
+            typeof previous.value === "string" &&
+            !hasExplicitBreak &&
+            !previous.value.includes("<br>") &&
+            !previous.value.includes("\n") &&
+            previous.style === run.style &&
+            normalizeMetadata(previous) === normalizeMetadata(run)
+        ) {
+            previous.value += run.value
+            continue
+        }
+
+        merged.push({ ...run })
+    }
+
+    return merged
+}


### PR DESCRIPTION
## Symtom:
After importing PowerPoint with text in non English language using Latin alphabets, applying Template causes random line breaks.

## Reproduce step
1. Create a PowerPoint file, with a text box containing the non-English language. Ex: "Ha-lê-lu-gia" (Hallelujah in Vietnamese).
2. Import the PowerPoint file as editable slide.
3. Apply a template

Expected: Template applied successfully, with no line break between the "Ha-lê-lu-gia" phrase
Actual: The phrase is broken into 2 lines:
- "Ha-lê"
- "lu-gia"

And the second hyphen is lost.

## Root cause analysis
PowerPoint text in non English language using Latin alphabets are usually flagged by Proof Reading/Spell Check as error. This causes the `<a:r>` tag to contain `err="1"` attribute.

With the above mentioned "Ha-lê-lu-gia" phrase, the actual XML data in the PowerPoint is as follow:
```
<a:rPr lang="en-US" dirty="0"/><a:t>Ha-</a:t></a:r><a:r><a:rPr lang="en-US" dirty="0" err="1"/><a:t>lê</a:t></a:r><a:r><a:rPr lang="en-US" dirty="0"/><a:t>-</a:t></a:r><a:r><a:rPr lang="en-US" dirty="0" err="1"/><a:t>lu-gia</a:t>
```

The importer currently turns each `<a:r>` run into its own text segment. The `err="1"` runs are not treated as a single logical string, so the rendered HTML ends up with multiple adjacent spans. That makes the browser wrap between them, causing line break.

Solution:
Update the PowerPoint importer to merge adjacent text segments when they:
- have the same computed style, and.
- are not separated by an explicit paragraph or line break.

That means the sequence with the err="1" runs in between should be imported as one continuous text run, so it stays on a single line instead of breaking.